### PR TITLE
[nix] シングルノード k3s 環境 (macOS: microvm.nix + vfkit VM / Linux: ホスト直接)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ tmp/
 result
 result-*
 
+# ローカル k3s 環境の状態 (nix run .#k3s-up)
+.k3s/
+

--- a/README.md
+++ b/README.md
@@ -102,6 +102,51 @@ frontend イメージは [static-web-server](https://static-web-server.net/) が
 
 イメージは Linux 用 derivation なので、macOS からビルドするには Linux builder が必要。[nix-darwin](https://github.com/nix-darwin/nix-darwin) の [`nix.linux-builder`](https://nix-darwin.github.io/nix-darwin/manual/#opt-nix.linux-builder.enable) を有効にするのが簡単(`nix flake check` は Linux builder が無くても通る)。
 
+## k3s 環境 (シングルノード)
+
+デプロイの既定はシングルノード k3s クラスタ ([ADR 0008](docs/adr/0008-topology-agnostic-manifests.md))。実行形態は OS で異なるが、操作は共通:
+
+- **macOS**: [microvm.nix](https://github.com/microvm-nix/microvm.nix) + [vfkit](https://github.com/crc-org/vfkit) の VM 1 台の中で k3s server が動く
+- **Linux**: ホストで k3s server が直接動く (systemd の一時 unit `dsa-k3s`)
+
+### 起動と停止
+
+```sh
+nix run .#k3s-up      # 起動し、ノードが Ready になるまで待つ
+export KUBECONFIG=$PWD/.k3s/kubeconfig
+kubectl get nodes     # 1 ノードが Ready
+
+nix run .#k3s-down    # 停止
+```
+
+状態はリポジトリ直下の `.k3s/` に置かれる (`DSA_K3S_STATE_DIR` で変更可):
+
+| ファイル | 内容 |
+| --- | --- |
+| `.k3s/kubeconfig` | ホスト用 kubeconfig (`k3s-up` が生成) |
+| `.k3s/var.img` | (macOS) VM の `/var`。クラスタ状態はここに永続化される |
+| `.k3s/vm.log` | (macOS) VM のコンソールログ |
+
+macOS でクラスタを初期化したいときは、`nix run .#k3s-down` してから `rm -rf .k3s` する。Linux のクラスタ状態はホストの `/var/lib/rancher/k3s` にある。
+
+### macOS の前提: linux builder
+
+VM の NixOS システムは `aarch64-linux` 用なので、ビルドには Linux builder が必要 (コンテナイメージと同じ前提)。[nix-darwin](https://github.com/nix-darwin/nix-darwin) で以下を有効にするのが簡単:
+
+```nix
+nix.linux-builder.enable = true;
+```
+
+適用後、`/etc/nix/machines` に `aarch64-linux` の builder が現れる。詳細は [nix-darwin のマニュアル](https://nix-darwin.github.io/nix-darwin/manual/#opt-nix.linux-builder.enable) を参照。
+
+### 制約と補足
+
+- macOS の VM は 4 vCPU / 4GB RAM / 20GB ディスク (スパース)。変更は `nix/k3s-vm.nix` の `mkDefault` 値を上書きする
+- VM の MAC アドレスは固定 (DHCP lease を安定させるため) なので、**VM は同時に 1 台しか起動できない**。worktree を複数作っても VM は共有される
+- ホスト → VM の接続は vmnet の NAT 越しに VM の IP へ直接行う。kubeconfig の接続先書き換えと TLS SAN の設定は VM 内の systemd サービスが自動で行う
+- Linux の `k3s-up` は `sudo systemd-run` を使う (systemd 前提、非 NixOS ホストでも動く)。`k3s-down` で server を止めてもワークロードのコンテナは残り、次回起動時に再管理される
+- macOS で VM が起動しないときは `.k3s/vm.log` を確認する。VM を foreground で起動してコンソールを見るには: `mkdir -p .k3s/share && cd .k3s && $(nix build --print-out-paths ..#k3s-vm)/bin/microvm-run`
+
 ## flake の検査
 
 ```sh

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "microvm": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "spectrum": "spectrum"
+      },
+      "locked": {
+        "lastModified": 1784395873,
+        "narHash": "sha256-2aNPMX+33DdK/tVXMabpVNRzFJ5m2IgYaaw8LL0Tb9Q=",
+        "owner": "microvm-nix",
+        "repo": "microvm.nix",
+        "rev": "0784796ba5c4ba17c58fce3c2c0cbccc60d22e84",
+        "type": "github"
+      },
+      "original": {
+        "owner": "microvm-nix",
+        "repo": "microvm.nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1784364478,
@@ -18,7 +39,24 @@
     },
     "root": {
       "inputs": {
+        "microvm": "microvm",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "spectrum": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783694892,
+        "narHash": "sha256-xO8f7Qng+18FK2UlB9vcrkxCaQMCt5WjCH24aW/11eg=",
+        "ref": "refs/heads/main",
+        "rev": "24c4346e30fdea8d8e80f34aec3554a15a667d24",
+        "revCount": 1410,
+        "type": "git",
+        "url": "https://spectrum-os.org/git/spectrum"
+      },
+      "original": {
+        "type": "git",
+        "url": "https://spectrum-os.org/git/spectrum"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,18 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    microvm = {
+      url = "github:microvm-nix/microvm.nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
-    { self, nixpkgs }:
+    {
+      self,
+      nixpkgs,
+      microvm,
+    }:
     let
       lib = nixpkgs.lib;
       systems = [
@@ -29,26 +37,47 @@
           frontend-image = import ./nix/frontend-image.nix { inherit pkgs frontend; };
         }
       );
+      # シングルノード k3s VM (ADR 0008)。macOS ホスト専用で、Linux ホストは
+      # VM を使わず k3s-up がホスト直接起動する (nix/k3s-apps.nix)。
+      # vfkit はホストとゲストのアーキテクチャ一致を要求するため aarch64-linux 固定。
+      k3sVm = lib.nixosSystem {
+        system = "aarch64-linux";
+        modules = [
+          microvm.nixosModules.microvm
+          ./nix/k3s-vm.nix
+          { microvm.vmHostPackages = nixpkgs.legacyPackages.aarch64-darwin; }
+        ];
+      };
     in
     {
       devShells = eachSystem (pkgs: import ./nix/devshells.nix { inherit pkgs; });
       formatter = eachSystem (pkgs: pkgs.nixfmt);
 
-      # darwin の *-image は aarch64-linux の derivation を指す。
+      nixosConfigurations.dsa-k3s = k3sVm;
+
+      # darwin の *-image と k3s-vm は aarch64-linux の derivation を含む。
       # macOS からのビルドには linux builder が必要 (README 参照)。
       packages = packagesFor // {
         aarch64-darwin = packagesFor.aarch64-darwin // {
           backend-image = packagesFor.aarch64-linux.backend-image;
           frontend-image = packagesFor.aarch64-linux.frontend-image;
+          k3s-vm = k3sVm.config.microvm.declaredRunner;
         };
       };
 
-      apps = lib.genAttrs systems (system: {
-        backend = {
-          type = "app";
-          program = "${self.packages.${system}.backend}/bin/server";
-        };
-      });
+      apps = lib.genAttrs systems (
+        system:
+        {
+          backend = {
+            type = "app";
+            program = "${self.packages.${system}.backend}/bin/server";
+          };
+        }
+        // import ./nix/k3s-apps.nix {
+          pkgs = nixpkgs.legacyPackages.${system};
+          k3sVmRunner = k3sVm.config.microvm.declaredRunner;
+        }
+      );
 
       # checks は packages から合成する。go test / vitest は各 derivation の checkPhase で走る。
       # darwin では *-image を含めない (linux builder 無しでも nix flake check が通るように)。

--- a/nix/k3s-apps.nix
+++ b/nix/k3s-apps.nix
@@ -1,0 +1,238 @@
+# k3s 環境の起動・停止 flake apps (`nix run .#k3s-up` / `.#k3s-down`)。
+#
+# macOS: microvm.nix + vfkit の VM (nix/k3s-vm.nix) をバックグラウンド起動する。
+# Linux: ホストで k3s server を systemd の一時 unit (dsa-k3s) として起動する。
+#
+# どちらも状態は state dir (既定: $PWD/.k3s、DSA_K3S_STATE_DIR で変更可) に置き、
+# 起動完了後は state dir 直下の kubeconfig で kubectl が使える。
+{
+  pkgs,
+  # macOS のみ: k3s VM の microvm runner パッケージ
+  k3sVmRunner,
+}:
+let
+  inherit (pkgs) lib;
+
+  toApp = drv: {
+    type = "app";
+    program = lib.getExe drv;
+    meta.description = drv.meta.description or "";
+  };
+
+  stateDirSnippet = ''
+    state_dir="''${DSA_K3S_STATE_DIR:-$PWD/.k3s}"
+  '';
+
+  # ノードが Ready になるまで待つ。API サーバーがまだ聴いていない・ノードが
+  # まだ登録されていない段階でも失敗しないよう、kubectl wait ではなく
+  # リトライループで判定する。
+  waitForNodeSnippet = ''
+    echo "Waiting for the node to become Ready ..."
+    node_ready=""
+    for _ in $(seq 180); do
+      if kubectl --kubeconfig "$state_dir/kubeconfig" get nodes --no-headers 2>/dev/null \
+        | awk '$2 == "Ready" { found = 1 } END { exit !found }'; then
+        node_ready=1
+        break
+      fi
+      sleep 1
+    done
+    if [ -z "$node_ready" ]; then
+      echo "Timed out waiting for the node to become Ready:" >&2
+      kubectl --kubeconfig "$state_dir/kubeconfig" get nodes >&2 || true
+      exit 1
+    fi
+    kubectl --kubeconfig "$state_dir/kubeconfig" get nodes
+    echo
+    echo "k3s is up. Point kubectl at it with:"
+    echo "  export KUBECONFIG=$state_dir/kubeconfig"
+  '';
+
+  # vfkit の REST API (control socket) で VM の生死を判定する
+  vmRunningSnippet = ''
+    vm_running() {
+      curl -sf --unix-socket control.sock http://vfkit/vm/state >/dev/null 2>&1
+    }
+  '';
+
+  darwinApps = {
+    k3s-up = toApp (
+      pkgs.writeShellApplication {
+        name = "k3s-up";
+        meta.description = "Start the single-node k3s VM and wait until the node is Ready";
+        runtimeInputs = with pkgs; [
+          curl
+          kubectl
+          coreutils
+          expect # unbuffer: vfkit の stdio コンソールに pty を与える
+        ];
+        text = ''
+          ${stateDirSnippet}
+          mkdir -p "$state_dir/share"
+          cd "$state_dir"
+
+          ${vmRunningSnippet}
+          started=0
+          if vm_running; then
+            echo "k3s VM is already running (state dir: $state_dir)"
+          else
+            rm -f share/kubeconfig control.sock
+            echo "Starting the k3s VM (log: $state_dir/vm.log) ..."
+            # vfkit はコンソールを stdio に繋ぐため pty が必要 (unbuffer が確保する)
+            nohup unbuffer ${k3sVmRunner}/bin/microvm-run > vm.log 2>&1 &
+            echo $! > vm.pid
+            started=1
+          fi
+
+          echo "Waiting for the VM to publish its kubeconfig ..."
+          for _ in $(seq 300); do
+            [ -s share/kubeconfig ] && break
+            if [ "$started" = 1 ] && ! kill -0 "$(cat vm.pid)" 2>/dev/null; then
+              echo "The VM process exited unexpectedly. Last log lines:" >&2
+              tail -n 20 vm.log >&2
+              exit 1
+            fi
+            sleep 1
+          done
+          if ! [ -s share/kubeconfig ]; then
+            echo "Timed out waiting for $state_dir/share/kubeconfig. Last log lines:" >&2
+            tail -n 20 vm.log >&2
+            exit 1
+          fi
+
+          install -m 600 share/kubeconfig kubeconfig
+          ${waitForNodeSnippet}
+        '';
+      }
+    );
+
+    k3s-down = toApp (
+      pkgs.writeShellApplication {
+        name = "k3s-down";
+        meta.description = "Gracefully shut down the single-node k3s VM";
+        runtimeInputs = with pkgs; [
+          curl
+          coreutils
+        ];
+        text = ''
+          ${stateDirSnippet}
+          cd "$state_dir" 2>/dev/null || {
+            echo "No state dir at $state_dir; nothing to stop."
+            exit 0
+          }
+
+          ${vmRunningSnippet}
+          if ! vm_running; then
+            echo "k3s VM is not running (state dir: $state_dir)"
+            exit 0
+          fi
+
+          echo "Requesting graceful shutdown ..."
+          # runner 同梱の microvm-shutdown は HTTP を話さず vfkit に 400 で
+          # 弾かれるため、REST API を直接叩く ("Stop" = 電源ボタン相当)
+          curl -sf --unix-socket control.sock \
+            -X POST -H "Content-Type: application/json" \
+            -d '{"state": "Stop"}' http://vfkit/vm/state
+
+          for _ in $(seq 90); do
+            vm_running || break
+            sleep 1
+          done
+          if vm_running; then
+            echo "Graceful shutdown timed out; forcing a hard stop." >&2
+            curl -sf --unix-socket control.sock \
+              -X POST -H "Content-Type: application/json" \
+              -d '{"state": "HardStop"}' http://vfkit/vm/state || true
+          fi
+          echo "k3s VM stopped."
+        '';
+      }
+    );
+  };
+
+  linuxApps =
+    let
+      unit = "dsa-k3s";
+      hostKubeconfig = "/etc/rancher/k3s/k3s.yaml";
+      # 非 NixOS ホスト (Ubuntu 等) でも動くよう、k3s が呼ぶ外部コマンドは
+      # nix store のものを unit の PATH に載せる。
+      k3sPath = lib.makeBinPath (
+        with pkgs;
+        [
+          k3s
+          util-linux
+          iptables
+          ipset
+          socat
+          conntrack-tools
+          ethtool
+          kmod
+          coreutils
+          findutils
+          gnugrep
+        ]
+      );
+    in
+    {
+      k3s-up = toApp (
+        pkgs.writeShellApplication {
+          name = "k3s-up";
+          meta.description = "Start a single-node k3s server on this host and wait until the node is Ready";
+          runtimeInputs = with pkgs; [
+            kubectl
+            coreutils
+          ];
+          text = ''
+            ${stateDirSnippet}
+            mkdir -p "$state_dir"
+
+            if systemctl is-active --quiet ${unit}; then
+              echo "k3s server is already running (systemd unit: ${unit})"
+            else
+              echo "Starting the k3s server as transient systemd unit ${unit} (requires sudo) ..."
+              sudo systemd-run --unit=${unit} \
+                --description="dsa-project single-node k3s server" \
+                --property=Environment=PATH=${k3sPath} \
+                ${pkgs.k3s}/bin/k3s server
+            fi
+
+            echo "Waiting for the kubeconfig ..."
+            for _ in $(seq 300); do
+              sudo test -s ${hostKubeconfig} && break
+              if ! systemctl is-active --quiet ${unit}; then
+                echo "Unit ${unit} is not running. Check: journalctl -u ${unit}" >&2
+                exit 1
+              fi
+              sleep 1
+            done
+            if ! sudo test -s ${hostKubeconfig}; then
+              echo "Timed out waiting for ${hostKubeconfig}. Check: journalctl -u ${unit}" >&2
+              exit 1
+            fi
+
+            # kubeconfig は root 所有 mode 600 のまま、自分の所有でコピーする
+            sudo install -m 600 -o "$(id -un)" -g "$(id -gn)" ${hostKubeconfig} "$state_dir/kubeconfig"
+            ${waitForNodeSnippet}
+          '';
+        }
+      );
+
+      k3s-down = toApp (
+        pkgs.writeShellApplication {
+          name = "k3s-down";
+          meta.description = "Stop the single-node k3s server running on this host";
+          text = ''
+            if systemctl is-active --quiet ${unit}; then
+              echo "Stopping systemd unit ${unit} (requires sudo) ..."
+              sudo systemctl stop ${unit}
+              echo "k3s server stopped. Note: workload containers keep running;"
+              echo "they are re-managed when the server is started again."
+            else
+              echo "k3s server is not running (systemd unit: ${unit})"
+            fi
+          '';
+        }
+      );
+    };
+in
+if pkgs.stdenv.isDarwin then darwinApps else linuxApps

--- a/nix/k3s-vm.nix
+++ b/nix/k3s-vm.nix
@@ -1,0 +1,139 @@
+# シングルノード k3s VM の NixOS 構成 (ADR 0008)。macOS ホストで microvm.nix +
+# vfkit により実行される (Linux ホストは VM を使わずホスト直接起動: k3s-apps.nix)。
+#
+# 相対パス (share/, control.sock, var.img) は runner プロセスの CWD 基準で解決
+# されるため、runner は必ず state dir (.k3s/) の中で起動すること (k3s-up が行う)。
+{ lib, pkgs, ... }:
+let
+  # vmnet の DHCP で割り当てられた自分の IPv4 アドレスを取得する。
+  # デフォルトルートの src アドレスを使うことで、インターフェース名に
+  # 依存せず、k3s 起動後に現れる cni0 等の Pod ネットワークも拾わない。
+  vmIpScript = ''
+    vm_ip=""
+    for _ in $(seq 60); do
+      vm_ip=$(ip route get 1.1.1.1 2>/dev/null | sed -n 's/.* src \([0-9.]*\).*/\1/p' | head -n1)
+      [ -n "$vm_ip" ] && break
+      sleep 1
+    done
+    if [ -z "$vm_ip" ]; then
+      echo "could not determine the VM's IPv4 address" >&2
+      exit 1
+    fi
+  '';
+in
+{
+  networking.hostName = "dsa-k3s";
+  system.stateVersion = lib.trivial.release;
+
+  microvm = {
+    hypervisor = "vfkit";
+    vcpu = lib.mkDefault 4;
+    mem = lib.mkDefault 4096;
+
+    # クラスタ状態 (/var/lib/rancher 以下など) を VM 再起動をまたいで保持する。
+    # スパースファイルなので実使用分しかホストのディスクを消費しない。
+    volumes = [
+      {
+        image = "var.img";
+        mountPoint = "/var";
+        size = lib.mkDefault 20480;
+      }
+    ];
+
+    # kubeconfig 受け渡し用。ホスト側 .k3s/share/ が VM 内 /share に見える。
+    shares = [
+      {
+        tag = "host-share";
+        source = "share";
+        mountPoint = "/share";
+        proto = "virtiofs";
+      }
+    ];
+
+    # vfkit は user (NAT / vmnet) のみサポート。MAC を固定して DHCP lease
+    # (= VM の IP) を安定させる。同じ MAC の VM は同時に 1 台しか起動できない。
+    interfaces = [
+      {
+        type = "user";
+        id = "eth0";
+        mac = "02:00:00:6b:33:73";
+      }
+    ];
+
+    # vfkit の control socket。k3s-down が graceful shutdown に使う。
+    socket = "control.sock";
+  };
+
+  services.k3s = {
+    enable = true;
+    role = "server";
+  };
+
+  networking.firewall = {
+    # ホストから NAT 越しに API サーバーへ接続する。
+    allowedTCPPorts = [ 6443 ];
+    # Pod/Service 間トラフィック (flannel vxlan / cni bridge) を妨げない。
+    trustedInterfaces = [
+      "cni0"
+      "flannel.1"
+    ];
+  };
+
+  # ホストは vmnet が割り当てた VM の IP へ直接接続するため、serving cert の
+  # SAN に自分の IP を載せる。k3s は /etc/rancher/k3s/config.yaml を自動で読む。
+  systemd.services.k3s-tls-san = {
+    description = "Write k3s config.yaml with the VM's IP as tls-san";
+    wantedBy = [ "multi-user.target" ];
+    requiredBy = [ "k3s.service" ];
+    before = [ "k3s.service" ];
+    after = [ "network-online.target" ];
+    wants = [ "network-online.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    path = with pkgs; [
+      iproute2
+      gnused
+      coreutils
+    ];
+    script = ''
+      ${vmIpScript}
+      mkdir -p /etc/rancher/k3s
+      cat > /etc/rancher/k3s/config.yaml <<EOF
+      tls-san:
+        - $vm_ip
+      EOF
+    '';
+  };
+
+  # k3s が生成した kubeconfig の接続先を VM の IP に書き換えてホストへ公開する。
+  systemd.services.k3s-export-kubeconfig = {
+    description = "Publish kubeconfig (server rewritten to the VM's IP) to the host share";
+    wantedBy = [ "multi-user.target" ];
+    wants = [ "k3s.service" ];
+    after = [ "k3s.service" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    path = with pkgs; [
+      iproute2
+      gnused
+      coreutils
+    ];
+    script = ''
+      for _ in $(seq 300); do
+        [ -s /etc/rancher/k3s/k3s.yaml ] && break
+        sleep 1
+      done
+      if ! [ -s /etc/rancher/k3s/k3s.yaml ]; then
+        echo "timed out waiting for /etc/rancher/k3s/k3s.yaml" >&2
+        exit 1
+      fi
+      ${vmIpScript}
+      sed "s#https://127.0.0.1:6443#https://$vm_ip:6443#" /etc/rancher/k3s/k3s.yaml > /share/kubeconfig.tmp
+      mv /share/kubeconfig.tmp /share/kubeconfig
+    '';
+  };
+}


### PR DESCRIPTION
Closes #82

## 概要

シングルノード k3s 環境 (ADR 0008) を nix flake から再現可能に立ち上げられるようにする。`nix run .#k3s-up` / `.#k3s-down` を macOS・Linux 共通のインターフェースとして追加。

- **macOS** (`nix/k3s-vm.nix`): microvm.nix + vfkit の VM (aarch64-linux ゲスト、4 vCPU / 4GB / 20GB スパース) 内で k3s server を起動
  - VM 内の systemd サービスが自身の IP を TLS SAN に設定し、接続先を書き換えた kubeconfig を virtiofs share 経由でホストへ公開
  - `/var` は `.k3s/var.img` に永続化 (VM 再起動をまたいでクラスタ状態が残る)
  - 停止は vfkit の REST API 経由の graceful shutdown (タイムアウト時は hard stop にフォールバック)
- **Linux** (`nix/k3s-apps.nix`): systemd 一時 unit `dsa-k3s` としてホスト直接起動。非 NixOS ホストでも動くよう k3s の依存コマンドは nix store のパスを unit に注入
- 両 OS とも起動後 `.k3s/kubeconfig` が生成され、`export KUBECONFIG=$PWD/.k3s/kubeconfig` で kubectl が使える
- README にセットアップ (linux-builder 前提含む)・起動停止・制約 (VM は同時 1 台) を追記

## 実装メモ

- vfkit はコンソールを stdio に繋ぎ TTY を要求するため、バックグラウンド起動時は `unbuffer` で pty を確保している
- microvm.nix 同梱の `microvm-shutdown` は生 JSON を socket に流すだけで vfkit の REST サーバーに 400 で弾かれるため、`k3s-down` は curl で正規の HTTP POST を送る
- kubeconfig はホスト側 mode 600 で扱い、Linux でも `--write-kubeconfig-mode=0644` は使わない

## 検証 (Acceptance criteria)

- [x] macOS ホスト (microvm.nix + vfkit の VM 内) で `kubectl get nodes` が 1 ノード Ready (`192.168.64.2:6443`、TLS 検証込み) — 実機確認済み
- [x] 起動・停止が flake app で再現できる (up/down とも冪等、graceful shutdown 約 6 秒、再起動後も namespace 残存を確認)
- [x] macOS の linux-builder 前提を含むセットアップ手順を README に記載
- [ ] Linux ホストでの実機確認 — 手元に環境が無いため未検証 (eval・shellcheck のみ)。Linux マシンでの `nix run .#k3s-up` 確認を推奨

`nix flake check --all-systems` 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PT6rNPjA4bjPYFrD3ouQho