### PR TITLE
[chart] Add Helm chart + E2E deploy apps (frontend + backend + Ingress)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ dev server は `/health` と `/api` を backend(`http://localhost:8080`)へ prox
 
 ## コンテナイメージ
 
-`nix build .#backend-image` / `nix build .#frontend-image` の出力はイメージ tar を stdout に流すスクリプト。タグは derivation hash 由来で、内容が変わればタグも変わる。k3s へは registry を経由せず直接 import できる:
+`nix build .#backend-image` / `nix build .#frontend-image` の出力はイメージ tar を stdout に流すスクリプト。タグは derivation hash 由来で、内容が変わればタグも変わる。k3s へは registry を経由せず直接 import できる(後述の `nix run .#k3s-load-images` がこれを自動で行う):
 
 ```sh
 nix build .#backend-image
@@ -147,10 +147,43 @@ nix.linux-builder.enable = true;
 - Linux の `k3s-up` は `sudo systemd-run` を使う (systemd 前提、非 NixOS ホストでも動く)。`k3s-down` で server を止めてもワークロードのコンテナは残り、次回起動時に再管理される
 - macOS で VM が起動しないときは `.k3s/vm.log` を確認する。VM を foreground で起動してコンソールを見るには: `mkdir -p .k3s/share && cd .k3s && $(nix build --print-out-paths ..#k3s-vm)/bin/microvm-run`
 
+## デプロイ (Helm chart)
+
+frontend + backend + Traefik Ingress を `chart/` の Helm chart でデプロイする。チューニング可能な値は `chart/values.yaml` に集約されている。manifest はクラスタのノード構成を仮定しない ([ADR 0008](docs/adr/0008-topology-agnostic-manifests.md))。
+
+k3s 環境が起動済みなら 1 コマンド:
+
+```sh
+nix run .#k3s-up       # 未起動の場合
+nix run .#k3s-deploy   # イメージ搬入 + helm upgrade --install
+```
+
+`k3s-deploy` は以下を行う:
+
+1. **イメージ搬入** (`nix run .#k3s-load-images` 単体でも実行可)
+   - macOS: イメージ tar を VM の share (`.k3s/share/images/`) に置き、VM 内の importer (systemd timer、`nix/k3s-vm.nix`) が containerd へ取り込む
+   - Linux: イメージの stream script をホストの containerd へ直接 pipe する (`sudo` が必要)
+2. **helm upgrade --install** — image tag は derivation hash 由来で毎ビルド変わるため、現在の tag を `--set` で自動的に渡す
+3. 完了後にアクセス URL (`http://<node-ip>/`) を表示する
+
+ブラウザで URL を開くと hello ページが表示され、backend の health check 結果 (`ok`) が出る。Ingress は `/health` と `/api` を backend へ、それ以外を frontend へ route する。
+
+helm を手動で使う場合は tag を明示する:
+
+```sh
+nix run .#k3s-load-images
+helm upgrade --install dsa chart/ \
+  --kubeconfig .k3s/kubeconfig \
+  --set backend.image.tag=$(nix eval --raw .#backend-image.imageTag) \
+  --set frontend.image.tag=$(nix eval --raw .#frontend-image.imageTag)
+```
+
+注意 (macOS): `nix/k3s-vm.nix` を変更しても起動中の VM には反映されない。`nix run .#k3s-down` してから `nix run .#k3s-up` で VM を作り直す。
+
 ## flake の検査
 
 ```sh
 nix flake check
 ```
 
-CI や手元での確認に使う。全サポートシステム分を評価する場合は `nix flake check --all-systems`。
+CI や手元での確認に使う。go test / vitest に加え、Helm chart の静的検証 (`helm lint` / `helm template`、`nix/chart-check.nix`) もここで走る。全サポートシステム分を評価する場合は `nix flake check --all-systems`。

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ nix run .#k3s-down    # 停止
 | ファイル | 内容 |
 | --- | --- |
 | `.k3s/kubeconfig` | ホスト用 kubeconfig (`k3s-up` が生成) |
+| `.k3s/ssh/` | (macOS) VM への SSH クライアント鍵 (`k3s-up` が生成) と known_hosts |
 | `.k3s/var.img` | (macOS) VM の `/var`。クラスタ状態はここに永続化される |
 | `.k3s/vm.log` | (macOS) VM のコンソールログ |
 
@@ -147,6 +148,7 @@ nix.linux-builder.enable = true;
 - VM の MAC アドレスは固定 (DHCP lease を安定させるため) なので、**VM は同時に 1 台しか起動できない**。worktree を複数作っても VM は共有される
 - ホスト → VM の接続は vmnet の NAT 越しに VM の IP へ直接行う。kubeconfig の接続先書き換えと TLS SAN の設定は VM 内の systemd サービスが自動で行う
 - Linux の `k3s-up` は `sudo systemd-run` を使う (systemd 前提、非 NixOS ホストでも動く)。`k3s-down` で server を止めてもワークロードのコンテナは残り、次回起動時に再管理される
+- macOS では `nix run .#k3s-ssh` で VM に root で入れる (`journalctl` や `k3s ctr` での調査用)。イメージ搬入も同じ SSH 経路を使う。引数は VM 上のコマンドとして実行される: `nix run .#k3s-ssh -- journalctl -u k3s`
 - macOS で VM が起動しないときは `.k3s/vm.log` を確認する。VM を foreground で起動してコンソールを見るには: `mkdir -p .k3s/share && cd .k3s && $(nix build --print-out-paths ..#k3s-vm)/bin/microvm-run`
 
 ## デプロイ (Helm chart)
@@ -163,7 +165,7 @@ nix run .#k3s-deploy   # イメージ搬入 + helm upgrade --install
 `k3s-deploy` は以下を行う:
 
 1. **イメージ搬入** (`nix run .#k3s-load-images` 単体でも実行可)
-   - macOS: イメージ tar を VM の share (`.k3s/share/images/`) に置き、VM 内の importer (systemd timer、`nix/k3s-vm.nix`) が containerd へ取り込む
+   - macOS: イメージ tar を SSH 越しに VM の `k3s ctr -n k8s.io images import -` へ pipe する
    - Linux: イメージの stream script をホストの containerd へ直接 pipe する (`sudo` が必要)
 2. **helm upgrade --install** — image tag は derivation hash 由来で毎ビルド変わるため、現在の tag を `--set` で自動的に渡す
 3. 完了後にアクセス URL (`http://<node-ip>/`) を表示する

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ nix build .#backend-image
 
 frontend イメージは [static-web-server](https://static-web-server.net/) が `:8080` で静的ファイルを配信する。
 
+この直接 import は既定のシングルノードデプロイ前提。chart は `imagePullPolicy: IfNotPresent` なので、マルチノードクラスタでは import されていないノードで `ErrImagePull` になる。マルチノードで動かす場合はレジストリを立てて push するか、全ノードに import すること。
+
 イメージは Linux 用 derivation なので、macOS からビルドするには Linux builder が必要。[nix-darwin](https://github.com/nix-darwin/nix-darwin) の [`nix.linux-builder`](https://nix-darwin.github.io/nix-darwin/manual/#opt-nix.linux-builder.enable) を有効にするのが簡単(`nix flake check` は Linux builder が無くても通る)。
 
 ## k3s 環境 (シングルノード)

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,8 @@
+apiVersion: v2
+name: dsa
+description: >-
+  DSA project online judge. Hello-world walking skeleton: frontend + backend +
+  Traefik Ingress. Datastores (PostgreSQL, Redis, OpenBao, Seaweedfs) are added
+  in later feature work.
+type: application
+version: 0.1.0

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -1,0 +1,15 @@
+{{ .Chart.Name }} ({{ .Release.Name }}) をデプロイしました。
+
+Ingress ({{ .Values.ingress.className }}) 経由でアクセスできます:
+{{- if .Values.ingress.host }}
+
+  http://{{ .Values.ingress.host }}/
+{{- else }}
+
+  http://<node-ip>/
+
+  node の IP は以下で取得できます:
+  kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}'
+{{- end }}
+
+hello ページに backend の health check 結果 (ok) が表示されれば疎通しています。

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,25 @@
+{{/*
+資源名の接頭辞。Release 名が chart 名を含む場合は Release 名をそのまま使う
+(helm create の慣例)。各資源は "<fullname>-backend" のように component を後置する。
+*/}}
+{{- define "dsa.fullname" -}}
+{{- if contains .Chart.Name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/* 共通ラベル。app.kubernetes.io/component は各 template が追加する */}}
+{{- define "dsa.labels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
+{{- end }}
+
+{{/* selector 用ラベル。selector は immutable なので最小限に保つ */}}
+{{- define "dsa.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/chart/templates/backend-deployment.yaml
+++ b/chart/templates/backend-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "dsa.fullname" . }}-backend
+  labels:
+    {{- include "dsa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  replicas: {{ .Values.backend.replicas }}
+  selector:
+    matchLabels:
+      {{- include "dsa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: backend
+  template:
+    metadata:
+      labels:
+        {{- include "dsa.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: backend
+    spec:
+      containers:
+        - name: backend
+          image: {{ .Values.backend.image.repository }}:{{ required "backend.image.tag is required (nix run .#k3s-deploy が現在の tag を渡す)" .Values.backend.image.tag }}
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+          resources:
+            {{- toYaml .Values.backend.resources | nindent 12 }}

--- a/chart/templates/backend-service.yaml
+++ b/chart/templates/backend-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dsa.fullname" . }}-backend
+  labels:
+    {{- include "dsa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+spec:
+  selector:
+    {{- include "dsa.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: backend
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/chart/templates/frontend-deployment.yaml
+++ b/chart/templates/frontend-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "dsa.fullname" . }}-frontend
+  labels:
+    {{- include "dsa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: {{ .Values.frontend.replicas }}
+  selector:
+    matchLabels:
+      {{- include "dsa.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
+  template:
+    metadata:
+      labels:
+        {{- include "dsa.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: {{ .Values.frontend.image.repository }}:{{ required "frontend.image.tag is required (nix run .#k3s-deploy が現在の tag を渡す)" .Values.frontend.image.tag }}
+          imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+          # static-web-server は SPA fallback で全パスに 200 を返すため / を probe に使う
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}

--- a/chart/templates/frontend-service.yaml
+++ b/chart/templates/frontend-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dsa.fullname" . }}-frontend
+  labels:
+    {{- include "dsa.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  selector:
+    {{- include "dsa.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -1,0 +1,37 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "dsa.fullname" . }}
+  labels:
+    {{- include "dsa.labels" . | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    # frontend は同一 origin の /health と /api を backend API として期待する
+    # (frontend/src/App.tsx)。最長パス一致で backend への route が優先される。
+    - http:
+        paths:
+          - path: /health
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "dsa.fullname" . }}-backend
+                port:
+                  name: http
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "dsa.fullname" . }}-backend
+                port:
+                  name: http
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "dsa.fullname" . }}-frontend
+                port:
+                  name: http
+      {{- with .Values.ingress.host }}
+      host: {{ quote . }}
+      {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,27 @@
+# チューニング可能な値はすべてこのファイルに集約する (仕様の可搬性要件)。
+# manifest はクラスタのノード構成を仮定しない (ADR 0008 Topology-Agnostic Manifests)。
+#
+# image tag は必須 (デフォルト無し)。nix dockerTools のイメージは内容依存の
+# tag を持つため、`nix run .#k3s-deploy` が現在の tag を --set で渡す。
+
+backend:
+  image:
+    repository: dsa-backend
+    tag: "" # 必須。空のままだと template がエラーになる
+    pullPolicy: IfNotPresent
+  replicas: 1
+  resources: {}
+
+frontend:
+  image:
+    repository: dsa-frontend
+    tag: "" # 必須。空のままだと template がエラーになる
+    pullPolicy: IfNotPresent
+  replicas: 1
+  resources: {}
+
+ingress:
+  # k3s 同梱の Traefik を既定とする。他の ingress controller を使う場合に上書きする
+  className: traefik
+  # 空なら全ホスト名にマッチする。特定ドメインで公開する場合に設定する
+  host: ""

--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,11 @@
 
       apps = lib.genAttrs systems (
         system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          # macOS は VM (aarch64-linux) 用のイメージを搬入する
+          imagePkgs = if pkgs.stdenv.isDarwin then packagesFor.aarch64-linux else packagesFor.${system};
+        in
         {
           backend = {
             type = "app";
@@ -74,13 +79,22 @@
           };
         }
         // import ./nix/k3s-apps.nix {
-          pkgs = nixpkgs.legacyPackages.${system};
+          inherit pkgs;
           k3sVmRunner = k3sVm.config.microvm.declaredRunner;
+          backendImage = imagePkgs.backend-image;
+          frontendImage = imagePkgs.frontend-image;
         }
       );
 
       # checks は packages から合成する。go test / vitest は各 derivation の checkPhase で走る。
       # darwin では *-image を含めない (linux builder 無しでも nix flake check が通るように)。
-      checks = packagesFor;
+      # chart-check は helm lint / template によるオフライン検証。
+      checks = eachSystem (
+        pkgs:
+        packagesFor.${pkgs.stdenv.hostPlatform.system}
+        // {
+          chart = import ./nix/chart-check.nix { inherit pkgs; };
+        }
+      );
     };
 }

--- a/nix/backend-image.nix
+++ b/nix/backend-image.nix
@@ -4,10 +4,18 @@
 # 出力はイメージ tar を stdout に流すスクリプト:
 #   nix build .#backend-image && ./result | k3s ctr -n k8s.io images import -
 { pkgs, backend }:
-pkgs.dockerTools.streamLayeredImage {
-  name = "dsa-backend";
-  config = {
-    Cmd = [ "${backend}/bin/server" ];
-    ExposedPorts."8080/tcp" = { };
+let
+  image = pkgs.dockerTools.streamLayeredImage {
+    name = "dsa-backend";
+    config = {
+      Cmd = [ "${backend}/bin/server" ];
+      ExposedPorts."8080/tcp" = { };
+    };
   };
+in
+image
+// {
+  # tar 実体。macOS ホストが VM の share 経由でイメージを搬入するときに使う
+  # (Linux ホストは stream script を直接 containerd へ pipe するので不要)。
+  tar = pkgs.runCommand "dsa-backend-image.tar" { } "${image} > $out";
 }

--- a/nix/backend-image.nix
+++ b/nix/backend-image.nix
@@ -5,17 +5,12 @@
 #   nix build .#backend-image && ./result | k3s ctr -n k8s.io images import -
 { pkgs, backend }:
 let
-  image = pkgs.dockerTools.streamLayeredImage {
-    name = "dsa-backend";
-    config = {
-      Cmd = [ "${backend}/bin/server" ];
-      ExposedPorts."8080/tcp" = { };
-    };
-  };
+  withTar = import ./image-tar.nix { inherit pkgs; };
 in
-image
-// {
-  # tar 実体。macOS ホストが VM の share 経由でイメージを搬入するときに使う
-  # (Linux ホストは stream script を直接 containerd へ pipe するので不要)。
-  tar = pkgs.runCommand "dsa-backend-image.tar" { } "${image} > $out";
-}
+withTar (pkgs.dockerTools.streamLayeredImage {
+  name = "dsa-backend";
+  config = {
+    Cmd = [ "${backend}/bin/server" ];
+    ExposedPorts."8080/tcp" = { };
+  };
+})

--- a/nix/chart-check.nix
+++ b/nix/chart-check.nix
@@ -1,0 +1,34 @@
+# Helm chart の静的検証 (nix flake check で走る)。
+# クラスタ不要のオフライン検証: helm lint --strict と helm template で
+# render し、期待する manifest が揃っているかを確認する。
+# image tag は required (values.yaml 参照) なのでダミー値を渡す。
+{ pkgs }:
+let
+  setFlags = "--set backend.image.tag=check --set frontend.image.tag=check";
+in
+pkgs.runCommand "chart-check"
+  {
+    nativeBuildInputs = [ pkgs.kubernetes-helm ];
+  }
+  ''
+    export HOME="$TMPDIR" # helm はキャッシュ dir を書く
+    helm lint --strict ${setFlags} ${../chart}
+    helm template dsa ${../chart} ${setFlags} > rendered.yaml
+
+    # 期待する manifest が一通り render されていること
+    for want in \
+      "kind: Deployment" \
+      "kind: Service" \
+      "kind: Ingress" \
+      "name: dsa-backend" \
+      "name: dsa-frontend" \
+      "image: dsa-backend:check" \
+      "image: dsa-frontend:check"; do
+      grep -q "$want" rendered.yaml || {
+        echo "chart-check: '$want' not found in rendered manifests" >&2
+        exit 1
+      }
+    done
+
+    touch $out
+  ''

--- a/nix/frontend-image.nix
+++ b/nix/frontend-image.nix
@@ -3,25 +3,21 @@
 # tag 未指定・stream 形式の理由は backend-image.nix のコメントを参照。
 { pkgs, frontend }:
 let
-  image = pkgs.dockerTools.streamLayeredImage {
-    name = "dsa-frontend";
-    config = {
-      Cmd = [
-        "${pkgs.static-web-server}/bin/static-web-server"
-        "--root"
-        "${frontend}"
-        "--port"
-        "8080"
-        # SPA ルーティング: 存在しないパスは index.html にフォールバックする
-        "--page-fallback"
-        "${frontend}/index.html"
-      ];
-      ExposedPorts."8080/tcp" = { };
-    };
-  };
+  withTar = import ./image-tar.nix { inherit pkgs; };
 in
-image
-// {
-  # tar 実体。用途は backend-image.nix のコメントを参照。
-  tar = pkgs.runCommand "dsa-frontend-image.tar" { } "${image} > $out";
-}
+withTar (pkgs.dockerTools.streamLayeredImage {
+  name = "dsa-frontend";
+  config = {
+    Cmd = [
+      "${pkgs.static-web-server}/bin/static-web-server"
+      "--root"
+      "${frontend}"
+      "--port"
+      "8080"
+      # SPA ルーティング: 存在しないパスは index.html にフォールバックする
+      "--page-fallback"
+      "${frontend}/index.html"
+    ];
+    ExposedPorts."8080/tcp" = { };
+  };
+})

--- a/nix/frontend-image.nix
+++ b/nix/frontend-image.nix
@@ -2,19 +2,26 @@
 # static-web-server が Vite のビルド成果物を配信する。
 # tag 未指定・stream 形式の理由は backend-image.nix のコメントを参照。
 { pkgs, frontend }:
-pkgs.dockerTools.streamLayeredImage {
-  name = "dsa-frontend";
-  config = {
-    Cmd = [
-      "${pkgs.static-web-server}/bin/static-web-server"
-      "--root"
-      "${frontend}"
-      "--port"
-      "8080"
-      # SPA ルーティング: 存在しないパスは index.html にフォールバックする
-      "--page-fallback"
-      "${frontend}/index.html"
-    ];
-    ExposedPorts."8080/tcp" = { };
+let
+  image = pkgs.dockerTools.streamLayeredImage {
+    name = "dsa-frontend";
+    config = {
+      Cmd = [
+        "${pkgs.static-web-server}/bin/static-web-server"
+        "--root"
+        "${frontend}"
+        "--port"
+        "8080"
+        # SPA ルーティング: 存在しないパスは index.html にフォールバックする
+        "--page-fallback"
+        "${frontend}/index.html"
+      ];
+      ExposedPorts."8080/tcp" = { };
+    };
   };
+in
+image
+// {
+  # tar 実体。用途は backend-image.nix のコメントを参照。
+  tar = pkgs.runCommand "dsa-frontend-image.tar" { } "${image} > $out";
 }

--- a/nix/image-tar.nix
+++ b/nix/image-tar.nix
@@ -1,0 +1,9 @@
+# streamLayeredImage に tar 実体を付与する共通ヘルパー。
+# tar は macOS ホストが VM の share 経由でイメージを搬入するときに使う
+# (Linux ホストは stream script を直接 containerd へ pipe するので不要)。
+{ pkgs }:
+image:
+image
+// {
+  tar = pkgs.runCommand "${image.imageName}-image.tar" { } "${image} > $out";
+}

--- a/nix/k3s-apps.nix
+++ b/nix/k3s-apps.nix
@@ -4,10 +4,10 @@
 #   macOS: microvm.nix + vfkit の VM (nix/k3s-vm.nix) をバックグラウンド起動する。
 #   Linux: ホストで k3s server を systemd の一時 unit (dsa-k3s) として起動する。
 # - k3s-load-images: dockerTools でビルドしたイメージをクラスタへ搬入する。
-#   macOS: tar を VM の share (/share/images) に置き、VM 内の polling importer
-#   (nix/k3s-vm.nix の k3s-image-import) が取り込むのを待つ。
+#   macOS: イメージ tar を SSH 越しに VM の `k3s ctr images import -` へ pipe する。
 #   Linux: stream script をホストの containerd へ直接 pipe する。
 # - k3s-deploy: k3s-load-images した上で Helm chart (chart/) を install する。
+# - k3s-ssh (macOS のみ): VM へ root で SSH する (調査用の正面玄関)。
 #
 # どれも状態は state dir (既定: $PWD/.k3s、DSA_K3S_STATE_DIR で変更可) に置き、
 # k3s-up 完了後は state dir 直下の kubeconfig で kubectl が使える。
@@ -106,50 +106,68 @@ let
 
   darwinApps =
     let
+      # VM へ SSH するための準備。cwd は state dir であること。
+      # IP は kubeconfig の server URL から、ホスト鍵は VM が share へ公開した
+      # ものから known_hosts を組み立て、TOFU せずに厳密検証する。
+      # (kubeconfig / host_key.pub は k3s-up が待つので、up 完了後は必ずある)
+      vmSshSnippet = ''
+        for f in kubeconfig share/ssh/host_key.pub ssh/id_ed25519; do
+          if [ ! -s "$f" ]; then
+            echo "$state_dir/$f not found; run 'nix run .#k3s-up' first" >&2
+            exit 1
+          fi
+        done
+        vm_ip=$(sed -n 's#.*server: https://\([0-9.]*\):6443#\1#p' kubeconfig | head -n1)
+        if [ -z "$vm_ip" ]; then
+          echo "could not parse the VM's IP from $state_dir/kubeconfig" >&2
+          exit 1
+        fi
+        printf '%s %s\n' "$vm_ip" "$(cut -d' ' -f1,2 share/ssh/host_key.pub)" > ssh/known_hosts
+        # -F /dev/null: ユーザーの ~/.ssh/config を読まない (macOS 固有オプション
+        # が nixpkgs の ssh で解釈できず落ちるのを防ぎ、挙動も決定的にする)
+        vm_ssh() {
+          ssh -F /dev/null \
+            -i ssh/id_ed25519 \
+            -o IdentitiesOnly=yes \
+            -o UserKnownHostsFile=ssh/known_hosts \
+            -o StrictHostKeyChecking=yes \
+            "root@$vm_ip" "$@"
+        }
+      '';
+      # VM と話す app 共通の runtime inputs (curl: control socket、sed: kubeconfig)
+      vmClientInputs = with pkgs; [
+        curl
+        coreutils
+        gnused
+        openssh
+      ];
+      # SSH を使う app 共通の前段: state dir へ移動し、VM の稼働を確認した上で
+      # vm_ssh を用意する。
+      requireVmSshSnippet = ''
+        ${stateDirSnippet}
+        cd "$state_dir" 2>/dev/null || {
+          echo "No state dir at $state_dir; run 'nix run .#k3s-up' first" >&2
+          exit 1
+        }
+
+        ${vmRunningSnippet}
+        if ! vm_running; then
+          echo "k3s VM is not running; run 'nix run .#k3s-up' first" >&2
+          exit 1
+        fi
+        ${vmSshSnippet}
+      '';
       loadImages = pkgs.writeShellApplication {
         name = "k3s-load-images";
         meta.description = "Import the container images into the k3s VM's containerd";
-        runtimeInputs = with pkgs; [
-          curl
-          coreutils
-        ];
+        runtimeInputs = vmClientInputs;
         text = ''
-          ${stateDirSnippet}
-          mkdir -p "$state_dir/share/images"
-          cd "$state_dir"
+          ${requireVmSshSnippet}
 
-          ${vmRunningSnippet}
-          if ! vm_running; then
-            echo "k3s VM is not running; run 'nix run .#k3s-up' first" >&2
-            exit 1
-          fi
-
-          # tar を share に置き、VM 内の importer (k3s-image-import) の結果を待つ。
-          # $1: share 内のファイル名 (拡張子なし)、$2: イメージ tar の store path
+          # $1: 表示名、$2: イメージ tar の store path
           import_image() {
-            base="share/images/$1"
-            rm -f "$base.ok" "$base.err"
-            cp "$2" "$base.tar.tmp"
-            mv "$base.tar.tmp" "$base.tar"
             echo "Importing $1 into the VM's containerd ..."
-            for _ in $(seq 180); do
-              if [ -e "$base.ok" ]; then
-                cat "$base.ok"
-                rm -f "$base.ok"
-                return 0
-              fi
-              if [ -e "$base.err" ]; then
-                echo "Image import failed inside the VM:" >&2
-                cat "$base.err" >&2
-                rm -f "$base.err"
-                return 1
-              fi
-              sleep 1
-            done
-            echo "Timed out waiting for the VM to import $1." >&2
-            echo "Hint: the VM may be running an old configuration without the importer;" >&2
-            echo "restart it with 'nix run .#k3s-down' then 'nix run .#k3s-up'." >&2
-            return 1
+            vm_ssh k3s ctr -n k8s.io images import - < "$2"
           }
 
           import_image "dsa-backend-${backendImage.imageTag}" ${backendImage.tar}
@@ -161,6 +179,18 @@ let
       k3s-load-images = toApp loadImages;
       k3s-deploy = toApp (mkDeploy loadImages);
 
+      k3s-ssh = toApp (
+        pkgs.writeShellApplication {
+          name = "k3s-ssh";
+          meta.description = "SSH into the k3s VM as root (arguments run as a command on the VM)";
+          runtimeInputs = vmClientInputs;
+          text = ''
+            ${requireVmSshSnippet}
+            vm_ssh "$@"
+          '';
+        }
+      );
+
       k3s-up = toApp (
         pkgs.writeShellApplication {
           name = "k3s-up";
@@ -169,19 +199,36 @@ let
             curl
             kubectl
             coreutils
+            openssh
             expect # unbuffer: vfkit の stdio コンソールに pty を与える
           ];
           text = ''
             ${stateDirSnippet}
-            mkdir -p "$state_dir/share"
+            mkdir -p "$state_dir/share/ssh"
             cd "$state_dir"
+
+            # VM への SSH 用クライアント鍵。VM は boot 時に share の公開鍵を
+            # root の authorized_keys へインストールする (nix/k3s-vm.nix)。
+            generated_key=0
+            if [ ! -s ssh/id_ed25519 ]; then
+              mkdir -p ssh
+              ssh-keygen -q -t ed25519 -N "" -C "dsa-k3s" -f ssh/id_ed25519
+              generated_key=1
+            fi
+            install -m 600 ssh/id_ed25519.pub share/ssh/authorized_keys
 
             ${vmRunningSnippet}
             started=0
             if vm_running; then
               echo "k3s VM is already running (state dir: $state_dir)"
+              # authorized_keys のインストールは boot 時のみ。稼働中の VM は
+              # いま生成した鍵を知らないので、再起動するまで SSH が通らない。
+              if [ "$generated_key" = 1 ]; then
+                echo "Warning: generated a new SSH client key, but the running VM only installs" >&2
+                echo "it at boot; run 'nix run .#k3s-down' then 'nix run .#k3s-up' to use SSH." >&2
+              fi
             else
-              rm -f share/kubeconfig control.sock
+              rm -f share/kubeconfig share/ssh/host_key.pub control.sock
               echo "Starting the k3s VM (log: $state_dir/vm.log) ..."
               # vfkit はコンソールを stdio に繋ぐため pty が必要 (unbuffer が確保する)
               nohup unbuffer ${k3sVmRunner}/bin/microvm-run > vm.log 2>&1 &
@@ -189,9 +236,9 @@ let
               started=1
             fi
 
-            echo "Waiting for the VM to publish its kubeconfig ..."
+            echo "Waiting for the VM to publish its SSH host key and kubeconfig ..."
             for _ in $(seq 300); do
-              [ -s share/kubeconfig ] && break
+              [ -s share/kubeconfig ] && [ -s share/ssh/host_key.pub ] && break
               if [ "$started" = 1 ] && ! kill -0 "$(cat vm.pid)" 2>/dev/null; then
                 echo "The VM process exited unexpectedly. Last log lines:" >&2
                 tail -n 20 vm.log >&2
@@ -199,8 +246,8 @@ let
               fi
               sleep 1
             done
-            if ! [ -s share/kubeconfig ]; then
-              echo "Timed out waiting for $state_dir/share/kubeconfig. Last log lines:" >&2
+            if ! { [ -s share/kubeconfig ] && [ -s share/ssh/host_key.pub ]; }; then
+              echo "Timed out waiting for $state_dir/share/{kubeconfig,ssh/host_key.pub}. Last log lines:" >&2
               tail -n 20 vm.log >&2
               exit 1
             fi

--- a/nix/k3s-apps.nix
+++ b/nix/k3s-apps.nix
@@ -1,17 +1,29 @@
-# k3s 環境の起動・停止 flake apps (`nix run .#k3s-up` / `.#k3s-down`)。
+# k3s 環境を操作する flake apps。
 #
-# macOS: microvm.nix + vfkit の VM (nix/k3s-vm.nix) をバックグラウンド起動する。
-# Linux: ホストで k3s server を systemd の一時 unit (dsa-k3s) として起動する。
+# - k3s-up / k3s-down: クラスタの起動・停止。
+#   macOS: microvm.nix + vfkit の VM (nix/k3s-vm.nix) をバックグラウンド起動する。
+#   Linux: ホストで k3s server を systemd の一時 unit (dsa-k3s) として起動する。
+# - k3s-load-images: dockerTools でビルドしたイメージをクラスタへ搬入する。
+#   macOS: tar を VM の share (/share/images) に置き、VM 内の polling importer
+#   (nix/k3s-vm.nix の k3s-image-import) が取り込むのを待つ。
+#   Linux: stream script をホストの containerd へ直接 pipe する。
+# - k3s-deploy: k3s-load-images した上で Helm chart (chart/) を install する。
 #
-# どちらも状態は state dir (既定: $PWD/.k3s、DSA_K3S_STATE_DIR で変更可) に置き、
-# 起動完了後は state dir 直下の kubeconfig で kubectl が使える。
+# どれも状態は state dir (既定: $PWD/.k3s、DSA_K3S_STATE_DIR で変更可) に置き、
+# k3s-up 完了後は state dir 直下の kubeconfig で kubectl が使える。
 {
   pkgs,
   # macOS のみ: k3s VM の microvm runner パッケージ
   k3sVmRunner,
+  # コンテナイメージ (Linux 用 derivation)。macOS では VM のアーキテクチャに
+  # 合わせた aarch64-linux のものが渡される (flake.nix)。
+  backendImage,
+  frontendImage,
 }:
 let
   inherit (pkgs) lib;
+
+  chart = ../chart;
 
   toApp = drv: {
     type = "app";
@@ -55,100 +67,193 @@ let
     }
   '';
 
-  darwinApps = {
-    k3s-up = toApp (
-      pkgs.writeShellApplication {
-        name = "k3s-up";
-        meta.description = "Start the single-node k3s VM and wait until the node is Ready";
+  # イメージ搬入後に chart を helm install し、アクセス URL を表示する。
+  # image tag は derivation hash 由来で毎ビルド変わり得るため、この app が
+  # 現在の tag を --set で values に渡す (chart/values.yaml 参照)。
+  mkDeploy =
+    loadImages:
+    pkgs.writeShellApplication {
+      name = "k3s-deploy";
+      meta.description = "Load the container images and install the Helm chart onto the k3s cluster";
+      runtimeInputs = with pkgs; [
+        kubernetes-helm
+        kubectl
+        coreutils
+      ];
+      text = ''
+        ${stateDirSnippet}
+        kubeconfig="$state_dir/kubeconfig"
+        if [ ! -s "$kubeconfig" ]; then
+          echo "kubeconfig not found at $kubeconfig; run 'nix run .#k3s-up' first" >&2
+          exit 1
+        fi
+
+        ${lib.getExe loadImages}
+
+        echo "Installing the Helm chart ..."
+        helm upgrade --install dsa ${chart} \
+          --kubeconfig "$kubeconfig" \
+          --set backend.image.tag=${backendImage.imageTag} \
+          --set frontend.image.tag=${frontendImage.imageTag} \
+          --wait --timeout 5m
+
+        node_ip=$(kubectl --kubeconfig "$kubeconfig" get nodes \
+          -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}')
+        echo
+        echo "Deployed. Open: http://$node_ip/"
+      '';
+    };
+
+  darwinApps =
+    let
+      loadImages = pkgs.writeShellApplication {
+        name = "k3s-load-images";
+        meta.description = "Import the container images into the k3s VM's containerd";
         runtimeInputs = with pkgs; [
           curl
-          kubectl
           coreutils
-          expect # unbuffer: vfkit の stdio コンソールに pty を与える
         ];
         text = ''
           ${stateDirSnippet}
-          mkdir -p "$state_dir/share"
+          mkdir -p "$state_dir/share/images"
           cd "$state_dir"
 
           ${vmRunningSnippet}
-          started=0
-          if vm_running; then
-            echo "k3s VM is already running (state dir: $state_dir)"
-          else
-            rm -f share/kubeconfig control.sock
-            echo "Starting the k3s VM (log: $state_dir/vm.log) ..."
-            # vfkit はコンソールを stdio に繋ぐため pty が必要 (unbuffer が確保する)
-            nohup unbuffer ${k3sVmRunner}/bin/microvm-run > vm.log 2>&1 &
-            echo $! > vm.pid
-            started=1
-          fi
-
-          echo "Waiting for the VM to publish its kubeconfig ..."
-          for _ in $(seq 300); do
-            [ -s share/kubeconfig ] && break
-            if [ "$started" = 1 ] && ! kill -0 "$(cat vm.pid)" 2>/dev/null; then
-              echo "The VM process exited unexpectedly. Last log lines:" >&2
-              tail -n 20 vm.log >&2
-              exit 1
-            fi
-            sleep 1
-          done
-          if ! [ -s share/kubeconfig ]; then
-            echo "Timed out waiting for $state_dir/share/kubeconfig. Last log lines:" >&2
-            tail -n 20 vm.log >&2
+          if ! vm_running; then
+            echo "k3s VM is not running; run 'nix run .#k3s-up' first" >&2
             exit 1
           fi
 
-          install -m 600 share/kubeconfig kubeconfig
-          ${waitForNodeSnippet}
-        '';
-      }
-    );
-
-    k3s-down = toApp (
-      pkgs.writeShellApplication {
-        name = "k3s-down";
-        meta.description = "Gracefully shut down the single-node k3s VM";
-        runtimeInputs = with pkgs; [
-          curl
-          coreutils
-        ];
-        text = ''
-          ${stateDirSnippet}
-          cd "$state_dir" 2>/dev/null || {
-            echo "No state dir at $state_dir; nothing to stop."
-            exit 0
+          # tar を share に置き、VM 内の importer (k3s-image-import) の結果を待つ。
+          # $1: share 内のファイル名 (拡張子なし)、$2: イメージ tar の store path
+          import_image() {
+            base="share/images/$1"
+            rm -f "$base.ok" "$base.err"
+            cp "$2" "$base.tar.tmp"
+            mv "$base.tar.tmp" "$base.tar"
+            echo "Importing $1 into the VM's containerd ..."
+            for _ in $(seq 180); do
+              if [ -e "$base.ok" ]; then
+                cat "$base.ok"
+                rm -f "$base.ok"
+                return 0
+              fi
+              if [ -e "$base.err" ]; then
+                echo "Image import failed inside the VM:" >&2
+                cat "$base.err" >&2
+                rm -f "$base.err"
+                return 1
+              fi
+              sleep 1
+            done
+            echo "Timed out waiting for the VM to import $1." >&2
+            echo "Hint: the VM may be running an old configuration without the importer;" >&2
+            echo "restart it with 'nix run .#k3s-down' then 'nix run .#k3s-up'." >&2
+            return 1
           }
 
-          ${vmRunningSnippet}
-          if ! vm_running; then
-            echo "k3s VM is not running (state dir: $state_dir)"
-            exit 0
-          fi
+          import_image "dsa-backend-${backendImage.imageTag}" ${backendImage.tar}
+          import_image "dsa-frontend-${frontendImage.imageTag}" ${frontendImage.tar}
+        '';
+      };
+    in
+    {
+      k3s-load-images = toApp loadImages;
+      k3s-deploy = toApp (mkDeploy loadImages);
 
-          echo "Requesting graceful shutdown ..."
-          # runner 同梱の microvm-shutdown は HTTP を話さず vfkit に 400 で
-          # 弾かれるため、REST API を直接叩く ("Stop" = 電源ボタン相当)
-          curl -sf --unix-socket control.sock \
-            -X POST -H "Content-Type: application/json" \
-            -d '{"state": "Stop"}' http://vfkit/vm/state
+      k3s-up = toApp (
+        pkgs.writeShellApplication {
+          name = "k3s-up";
+          meta.description = "Start the single-node k3s VM and wait until the node is Ready";
+          runtimeInputs = with pkgs; [
+            curl
+            kubectl
+            coreutils
+            expect # unbuffer: vfkit の stdio コンソールに pty を与える
+          ];
+          text = ''
+            ${stateDirSnippet}
+            mkdir -p "$state_dir/share"
+            cd "$state_dir"
 
-          for _ in $(seq 90); do
-            vm_running || break
-            sleep 1
-          done
-          if vm_running; then
-            echo "Graceful shutdown timed out; forcing a hard stop." >&2
+            ${vmRunningSnippet}
+            started=0
+            if vm_running; then
+              echo "k3s VM is already running (state dir: $state_dir)"
+            else
+              rm -f share/kubeconfig control.sock
+              echo "Starting the k3s VM (log: $state_dir/vm.log) ..."
+              # vfkit はコンソールを stdio に繋ぐため pty が必要 (unbuffer が確保する)
+              nohup unbuffer ${k3sVmRunner}/bin/microvm-run > vm.log 2>&1 &
+              echo $! > vm.pid
+              started=1
+            fi
+
+            echo "Waiting for the VM to publish its kubeconfig ..."
+            for _ in $(seq 300); do
+              [ -s share/kubeconfig ] && break
+              if [ "$started" = 1 ] && ! kill -0 "$(cat vm.pid)" 2>/dev/null; then
+                echo "The VM process exited unexpectedly. Last log lines:" >&2
+                tail -n 20 vm.log >&2
+                exit 1
+              fi
+              sleep 1
+            done
+            if ! [ -s share/kubeconfig ]; then
+              echo "Timed out waiting for $state_dir/share/kubeconfig. Last log lines:" >&2
+              tail -n 20 vm.log >&2
+              exit 1
+            fi
+
+            install -m 600 share/kubeconfig kubeconfig
+            ${waitForNodeSnippet}
+          '';
+        }
+      );
+
+      k3s-down = toApp (
+        pkgs.writeShellApplication {
+          name = "k3s-down";
+          meta.description = "Gracefully shut down the single-node k3s VM";
+          runtimeInputs = with pkgs; [
+            curl
+            coreutils
+          ];
+          text = ''
+            ${stateDirSnippet}
+            cd "$state_dir" 2>/dev/null || {
+              echo "No state dir at $state_dir; nothing to stop."
+              exit 0
+            }
+
+            ${vmRunningSnippet}
+            if ! vm_running; then
+              echo "k3s VM is not running (state dir: $state_dir)"
+              exit 0
+            fi
+
+            echo "Requesting graceful shutdown ..."
+            # runner 同梱の microvm-shutdown は HTTP を話さず vfkit に 400 で
+            # 弾かれるため、REST API を直接叩く ("Stop" = 電源ボタン相当)
             curl -sf --unix-socket control.sock \
               -X POST -H "Content-Type: application/json" \
-              -d '{"state": "HardStop"}' http://vfkit/vm/state || true
-          fi
-          echo "k3s VM stopped."
-        '';
-      }
-    );
-  };
+              -d '{"state": "Stop"}' http://vfkit/vm/state
+
+            for _ in $(seq 90); do
+              vm_running || break
+              sleep 1
+            done
+            if vm_running; then
+              echo "Graceful shutdown timed out; forcing a hard stop." >&2
+              curl -sf --unix-socket control.sock \
+                -X POST -H "Content-Type: application/json" \
+                -d '{"state": "HardStop"}' http://vfkit/vm/state || true
+            fi
+            echo "k3s VM stopped."
+          '';
+        }
+      );
+    };
 
   linuxApps =
     let
@@ -172,8 +277,23 @@ let
           gnugrep
         ]
       );
+      loadImages = pkgs.writeShellApplication {
+        name = "k3s-load-images";
+        meta.description = "Import the container images into the host k3s server's containerd";
+        text = ''
+          # stream script を containerd (k8s.io namespace) へ直接 pipe する。
+          # containerd の socket は root 所有のため sudo が要る。
+          echo "Importing dsa-backend:${backendImage.imageTag} (requires sudo) ..."
+          ${backendImage} | sudo ${pkgs.k3s}/bin/k3s ctr -n k8s.io images import -
+          echo "Importing dsa-frontend:${frontendImage.imageTag} ..."
+          ${frontendImage} | sudo ${pkgs.k3s}/bin/k3s ctr -n k8s.io images import -
+        '';
+      };
     in
     {
+      k3s-load-images = toApp loadImages;
+      k3s-deploy = toApp (mkDeploy loadImages);
+
       k3s-up = toApp (
         pkgs.writeShellApplication {
           name = "k3s-up";

--- a/nix/k3s-vm.nix
+++ b/nix/k3s-vm.nix
@@ -70,8 +70,13 @@ in
   };
 
   networking.firewall = {
-    # ホストから NAT 越しに API サーバーへ接続する。
-    allowedTCPPorts = [ 6443 ];
+    # 6443: ホストから NAT 越しに API サーバーへ接続する。
+    # 80/443: Traefik Ingress (ServiceLB がノードの 80/443 で受ける) へのアクセス。
+    allowedTCPPorts = [
+      6443
+      80
+      443
+    ];
     # Pod/Service 間トラフィック (flannel vxlan / cni bridge) を妨げない。
     trustedInterfaces = [
       "cni0"
@@ -105,6 +110,40 @@ in
         - $vm_ip
       EOF
     '';
+  };
+
+  # ホストが /share/images に置いたイメージ tar を containerd (k8s.io namespace)
+  # へ取り込む (k3s-load-images が置く)。virtiofs はホスト側の書き込みを inotify
+  # で通知しないため、systemd path unit ではなく timer で polling する。
+  # プロトコル: ホストは <name>.tar を置き (.tmp からの rename でアトミックに)、
+  # 取り込み結果として <name>.ok または <name>.err が現れるのを待つ。
+  systemd.services.k3s-image-import = {
+    description = "Import image tarballs from /share/images into k3s containerd";
+    path = [ pkgs.k3s ];
+    serviceConfig.Type = "oneshot";
+    script = ''
+      dir=/share/images
+      [ -d "$dir" ] || exit 0
+      for f in "$dir"/*.tar; do
+        [ -e "$f" ] || continue
+        name="''${f%.tar}"
+        if k3s ctr -n k8s.io images import "$f" > "$name.log" 2>&1; then
+          mv "$name.log" "$name.ok"
+        else
+          mv "$name.log" "$name.err"
+        fi
+        rm -f "$f"
+      done
+    '';
+  };
+  systemd.timers.k3s-image-import = {
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnBootSec = "10s";
+      OnUnitActiveSec = "2s";
+      # 既定の AccuracySec (1min) だと 2s 間隔が丸められるため明示する
+      AccuracySec = "1s";
+    };
   };
 
   # k3s が生成した kubeconfig の接続先を VM の IP に書き換えてホストへ公開する。

--- a/nix/k3s-vm.nix
+++ b/nix/k3s-vm.nix
@@ -40,7 +40,7 @@ in
       }
     ];
 
-    # kubeconfig 受け渡し用。ホスト側 .k3s/share/ が VM 内 /share に見える。
+    # kubeconfig と SSH 鍵の受け渡し用。ホスト側 .k3s/share/ が VM 内 /share に見える。
     shares = [
       {
         tag = "host-share";
@@ -70,9 +70,11 @@ in
   };
 
   networking.firewall = {
+    # 22: ホストからの SSH (image import と VM 内の調査に使う)。
     # 6443: ホストから NAT 越しに API サーバーへ接続する。
     # 80/443: Traefik Ingress (ServiceLB がノードの 80/443 で受ける) へのアクセス。
     allowedTCPPorts = [
+      22
       6443
       80
       443
@@ -112,38 +114,54 @@ in
     '';
   };
 
-  # ホストが /share/images に置いたイメージ tar を containerd (k8s.io namespace)
-  # へ取り込む (k3s-load-images が置く)。virtiofs はホスト側の書き込みを inotify
-  # で通知しないため、systemd path unit ではなく timer で polling する。
-  # プロトコル: ホストは <name>.tar を置き (.tmp からの rename でアトミックに)、
-  # 取り込み結果として <name>.ok または <name>.err が現れるのを待つ。
-  systemd.services.k3s-image-import = {
-    description = "Import image tarballs from /share/images into k3s containerd";
-    path = [ pkgs.k3s ];
-    serviceConfig.Type = "oneshot";
+  # ホストからの SSH 受け口。k3s-load-images がイメージ tar を
+  # `k3s ctr images import -` へストリームするのと、k3s-ssh での調査に使う。
+  # 認証は鍵のみ。クライアント公開鍵は k3s-up が VM 起動前に
+  # /share/ssh/authorized_keys へ置く (リポジトリに鍵は含めない)。
+  services.openssh = {
+    enable = true;
+    settings = {
+      PermitRootLogin = "prohibit-password";
+      PasswordAuthentication = false;
+      KbdInteractiveAuthentication = false;
+    };
+  };
+
+  # ホストの公開鍵を share から root の authorized_keys へインストールする。
+  # sshd は StrictModes で authorized_keys の所有権を検査するため、virtiofs 上の
+  # ファイルを直接参照させず boot 時にコピーする。
+  systemd.services.ssh-install-authorized-keys = {
+    description = "Install the host's SSH public key from the share";
+    wantedBy = [ "multi-user.target" ];
+    requiredBy = [ "sshd.service" ];
+    before = [ "sshd.service" ];
+    unitConfig.RequiresMountsFor = [ "/share" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
     script = ''
-      dir=/share/images
-      [ -d "$dir" ] || exit 0
-      for f in "$dir"/*.tar; do
-        [ -e "$f" ] || continue
-        name="''${f%.tar}"
-        if k3s ctr -n k8s.io images import "$f" > "$name.log" 2>&1; then
-          mv "$name.log" "$name.ok"
-        else
-          mv "$name.log" "$name.err"
-        fi
-        rm -f "$f"
-      done
+      install -d -m 700 /root/.ssh
+      install -m 600 /share/ssh/authorized_keys /root/.ssh/authorized_keys
     '';
   };
-  systemd.timers.k3s-image-import = {
-    wantedBy = [ "timers.target" ];
-    timerConfig = {
-      OnBootSec = "10s";
-      OnUnitActiveSec = "2s";
-      # 既定の AccuracySec (1min) だと 2s 間隔が丸められるため明示する
-      AccuracySec = "1s";
+
+  # sshd のホスト公開鍵を share へ公開する。ホスト側はこれと VM の IP から
+  # known_hosts を組み立てて厳密検証する (TOFU をしない)。
+  systemd.services.ssh-export-host-key = {
+    description = "Publish the sshd host public key to the host share";
+    wantedBy = [ "multi-user.target" ];
+    wants = [ "sshd.service" ];
+    after = [ "sshd.service" ];
+    unitConfig.RequiresMountsFor = [ "/share" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
     };
+    script = ''
+      cp /etc/ssh/ssh_host_ed25519_key.pub /share/ssh/host_key.pub.tmp
+      mv /share/ssh/host_key.pub.tmp /share/ssh/host_key.pub
+    '';
   };
 
   # k3s が生成した kubeconfig の接続先を VM の IP に書き換えてホストへ公開する。


### PR DESCRIPTION
## Summary

Closes #83 (part of #76)

Helm chart を追加し、#91 の k3s 環境上に frontend + backend をデプロイして、Traefik Ingress 経由でブラウザから hello ページ(backend health check 結果の表示つき)が見える E2E の縦串を通す。

- **chart は 1 つ、チューナブルは `chart/values.yaml` に集約**(replicas / image / resources / ingress class・host)。Topology-Agnostic Manifests(ADR 0008)に従い、テンプレートに hostPath / nodeSelector / affinity 等のノード仮定なし
- **イメージ搬入**: nix dockerTools(streamLayeredImage)でビルドしたイメージをレジストリを介さず import する `nix run .#k3s-load-images` を提供。macOS はイメージ tar を SSH 越しに VM の `k3s ctr images import -` へストリーム、Linux は containerd へ直接 pipe
- **VM への SSH** (macOS): `k3s-up` が `.k3s/ssh/` に鍵ペアを生成し、公開鍵を share 経由で VM に渡す(リポジトリに鍵は含めない)。sshd ホスト鍵も share 経由で受け取り毎回厳密検証(TOFU なし)。調査用の正面玄関として `nix run .#k3s-ssh` を追加
- **一発デプロイ**: `nix run .#k3s-deploy` が搬入 + `helm upgrade --install` を実行。image tag は derivation hash 由来(内容が変われば tag も変わり rollout が起きる)のため、現在の tag を `--set` で自動注入
- **オフライン検証**: `nix flake check` に chart 検証(helm lint --strict / helm template + 描画結果の検証)を追加

## Review

/code-review(Standards: ADR 0005/0006/0008 + smell baseline、Spec: Issue #83)実施済み。ハード違反なし。指摘対応として image tar ラッパーの重複を `nix/image-tar.nix`(`withTar`)に抽出し、README にマルチノード時はレジストリが必要な旨を追記(`imagePullPolicy: IfNotPresent` のため import されていないノードでは ErrImagePull)。

SSH push 化(b7bd62a)も /code-review 実施済み: 共通前段の snippet 抽出、`vm_ip` パース失敗の明示エラー、稼働中 VM に新規生成鍵が届かないケースの警告を反映。

## Notes

- 当初 macOS の搬入は「share に tar を置き VM 内の systemd timer が polling で取り込む」方式だったが、非同期ファイルプロトコル(`.tmp`/`.ok`/`.err`)の複雑さと診断性の悪さから SSH push に変更(b7bd62a)。エラーが同期的に返り、Linux ホスト実装と同型になる
- AC「Linux / macOS 両ホストで E2E 再現」のうち **Linux ホストでの E2E 確認は後続 Issue に切り出し**(macOS は確認済み)
- AC「helm install 一発」は、image tag が `required`(デフォルトなし)のため素の `helm install` ではなく `nix run .#k3s-deploy` が実体。手動手順(`--set` で tag 指定)も README に記載
- PostgreSQL / Redis / OpenBao / Seaweedfs は機能実装フェーズで追加予定(chart は hello world 最小構成)

## Test plan

- [x] `nix flake check` / chart 検証(helm lint --strict + helm template)通過
- [x] backend(go test)・frontend(vitest)チェック通過
- [x] macOS: k3s 環境起動 → `nix run .#k3s-deploy` → ブラウザで Ingress 経由の hello ページ + backend health check 表示
- [x] macOS: SSH 経路の E2E(`k3s-ssh` 疎通 → `k3s-load-images` → `k3s-deploy` → `curl /health` が `ok`)
- [ ] Linux ホストでの E2E(後続 Issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5Ytd1c6kxxEvzJGdxWs6y
https://claude.ai/code/session_01DYYMVAmSjm5ZevwzUyYMVG
