### PR TITLE
[ci] nix ベースの build / test (GitHub Actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+# PR と main push で nix flake check を回す最小 CI。
+# x86_64-linux の checks には backend-image / frontend-image が含まれるため、
+# flake check だけでコンテナイメージのビルド検証もカバーされる (flake.nix 参照)。
+# キャッシュは GitHub Actions cache に /nix/store を保存する cache-nix-action を使う
+# (magic-nix-cache は 2025-02 にサービス終了)。
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# 同一 ref の実行は 1 つに絞り、PR への連続 push では古い実行をキャンセルする
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # cache-nix-action の purge (古いキャッシュの削除) に必要
+  actions: write
+
+jobs:
+  flake-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: nixbuild/nix-quick-install-action@v35
+        with:
+          # GC でツールチェインや flake input が飛ばないよう保持する
+          # (cache-nix-action の README 推奨設定)
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          # 依存が変わると *.nix の vendorHash / npmDepsHash も変わるので、
+          # このキーで go / npm 依存の変更まで追従できる
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          # 保存前に GC してキャッシュサイズを抑える (repo 全体の上限は 10GB)
+          gc-max-store-size-linux: 4G
+          # 現在の ref のキャッシュのうち、primary-key 以外の古い世代を削除する
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
+          purge-created: 0
+          purge-primary-key: never
+
+      - name: nix flake check
+        run: nix flake check -L
+
+      # flake check でビルド済みなのでここはほぼ no-op だが、
+      # イメージビルドの成否を独立したステップとして見えるようにする
+      - name: Build container images
+        run: nix build -L .#backend-image .#frontend-image

--- a/README.md
+++ b/README.md
@@ -191,3 +191,5 @@ nix flake check
 ```
 
 CI や手元での確認に使う。go test / vitest に加え、Helm chart の静的検証 (`helm lint` / `helm template`、`nix/chart-check.nix`) もここで走る。全サポートシステム分を評価する場合は `nix flake check --all-systems`。
+
+GitHub Actions (`.github/workflows/ci.yml`) が PR と main への push で同じ `nix flake check` を実行する。Linux runner では checks にコンテナイメージ (`backend-image` / `frontend-image`) のビルドも含まれる。Nix store は [cache-nix-action](https://github.com/nix-community/cache-nix-action) で GitHub Actions cache にキャッシュされる。


### PR DESCRIPTION
## Summary

Closes #84

PR と main push で nix ベースのビルド・テストを回す最小の CI を追加する。

- `ubuntu-latest` (x86_64-linux) で `nix flake check` を実行。この system の checks には backend (go test) / frontend (vitest) / backend-image / frontend-image / chart (helm lint / template) が含まれるため、1 コマンドでコンテナイメージのビルド検証までカバーされる
- イメージビルドの成否が独立して見えるよう、`nix build .#backend-image .#frontend-image` を別ステップとして実行(flake check でビルド済みなのでほぼ no-op)
- キャッシュは [cache-nix-action](https://github.com/nix-community/cache-nix-action) で /nix/store を GitHub Actions cache に保存。issue 記載の magic-nix-cache は 2025-02 にサービス終了のため、外部アカウント不要なこちらを採用(選定はリポジトリオーナー承認済み)
- 同一 ref の連続実行はキャンセルし、古い世代のキャッシュは purge して 10GB 上限内に収める

## Acceptance criteria

- [x] PR と main push で `nix flake check` が実行される
- [x] frontend / backend のイメージビルドが CI で検証される
- [x] キャッシュが効いており、2 回目以降の CI が初回より明確に速い(実測: `nix flake check` 初回 60s → 2 回目 4s、[run](https://github.com/dsa-uts/dsa-project/actions/runs/30273657767))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMfXhcSPCFL2KhSxfDj9dU
