### PR TITLE
frontend の Nix ビルドを lockfile 駆動にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ npm run lint      # oxlint
 
 dev server は `/health` と `/api` を backend(`http://localhost:8080`)へ proxy する(`frontend/vite.config.ts`)。別ターミナルで `nix run .#backend` を起動しておくと、hello ページに backend の health check 結果が表示される。
 
-依存を変更したら `nix/frontend.nix` の `npmDepsHash` を更新する(`pkgs.lib.fakeHash` に置き換えて `nix build .#frontend` し、エラーに出る正しい hash を貼り直す)。
+依存を変更したら `package.json` と `package-lock.json` をコミットする。Nix の frontend build は lockfile から依存を取得するため、Nix 固有の dependency hash の更新は不要。
 
 ## コンテナイメージ
 

--- a/nix/frontend.nix
+++ b/nix/frontend.nix
@@ -1,12 +1,11 @@
 # frontend の静的ビルド成果物 (Vite の dist)。flake.nix から system ごとに import される。
-# package.json / package-lock.json を変更したら npmDepsHash を更新すること
-# (lib.fakeHash に置き換えて nix build し、エラーに出る正しい hash を貼り直す)。
 { pkgs }:
 pkgs.buildNpmPackage {
   pname = "dsa-frontend";
   version = "0.1.0";
   src = ../frontend;
-  npmDepsHash = "sha256-2njR6ENETtBs8b7CnSA1cfGLyW79waCUahM4V94w4pM=";
+  npmDeps = pkgs.importNpmLock { npmRoot = ../frontend; };
+  npmConfigHook = pkgs.importNpmLock.npmConfigHook;
   nodejs = pkgs.nodejs_24;
 
   # `npm run build` (tsc -b && vite build) が buildPhase で走る。


### PR DESCRIPTION
Closes #115

## 概要

frontend の npm 依存を `package.json` と `package-lock.json` から再現可能に取得し、Nix 固有の `npmDepsHash` を手動更新せずに frontend と frontend image をビルドできるようにします。

## 変更内容

- `buildNpmPackage` の依存取得を `pkgs.importNpmLock` と専用の `npmConfigHook` に変更
- `npmDepsHash` とその手動更新手順を削除
- README を lockfile 駆動の依存更新手順に更新

既存の Nix checks では frontend derivation が Vitest、`tsc -b`、Vite production build を実行し、frontend image check がその成果物からコンテナイメージを構築します。

## 検証

- [x] `nix build .#frontend --no-link --print-build-logs`
- [x] `nix build .#frontend-image --no-link --print-build-logs`
- [x] `nix flake check --print-build-logs`
- [x] `git diff --check`

## Review

`/code-review` を実施済みです。

- Standards: 指摘なし
- Spec (Issue #115): 指摘なし