### PR TITLE
backend 依存 metadata の refresh と drift 検査を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,13 @@ jobs:
           purge-created: 0
           purge-primary-key: never
 
+      # backend build より先に実行し、stale hash では Nix の hash mismatch ではなく
+      # 修復コマンドを含む専用エラーを表示する。check は checkout を変更しない。
+      - name: Test and check backend dependency metadata
+        run: |
+          bash scripts/backend-deps-test.sh
+          nix run .#backend-deps-check
+
       - name: nix flake check
         run: nix flake check -L
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cd frontend && npm run generate     # → frontend/src/api/schema.d.ts (openapi-
 ```sh
 nix run .#backend           # サーバー起動 (PORT 環境変数で変更可、既定 8080)
 nix build .#backend         # バイナリ
-nix build .#backend-image   # コンテナイメージ (下記参照)
+nix run .#backend-image-build  # 依存 metadata を refresh してコンテナイメージをビルド
 ```
 
 `DATABASE_URL`(例: `postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable`)が設定されていれば起動時に PostgreSQL へ接続し、`backend/internal/store/migrations/` の migration を自動適用する。未設定なら DB なしで起動する(DB を使うエンドポイントは 500 を返す)。
@@ -82,7 +82,16 @@ go test ./...          # DB テストを含む (Docker が必要: testcontainers
 go test -short ./...   # DB テストを skip (nix sandbox の checkPhase はこちら)
 ```
 
-依存を変更したら `go mod tidy` の後に `nix/backend.nix` の `vendorHash` を更新する(`pkgs.lib.fakeHash` に置き換えて `nix build .#backend` し、エラーに出る正しい hash を貼り直す)。
+依存を変更したら `go mod tidy` を実行する。開発向けの backend image build と
+deploy は、ビルド前に Nix の依存 metadata (`nix/backend-vendor-hash.nix`) を検査し、
+必要なら自動更新する。更新結果はコミットされず、レビュー可能な作業ツリー変更として残る。
+
+依存 metadata だけを明示的に修復・検査する場合は次を使う:
+
+```sh
+nix run .#backend-deps-refresh # drift があれば作業ツリーを更新
+nix run .#backend-deps-check   # checkout を変更せず drift を検査 (CI と同じ)
+```
 
 ## frontend の開発とビルド
 
@@ -108,10 +117,10 @@ dev server は `/health` と `/api` を backend(`http://localhost:8080`)へ prox
 
 ## コンテナイメージ
 
-`nix build .#backend-image` / `nix build .#frontend-image` の出力はイメージ tar を stdout に流すスクリプト。タグは derivation hash 由来で、内容が変わればタグも変わる。k3s へは registry を経由せず直接 import できる(後述の `nix run .#k3s-load-images` がこれを自動で行う):
+`nix run .#backend-image-build` / `nix build .#frontend-image` の出力はイメージ tar を stdout に流すスクリプト。タグは derivation hash 由来で、内容が変わればタグも変わる。k3s へは registry を経由せず直接 import できる(後述の `nix run .#k3s-load-images` がこれを自動で行う):
 
 ```sh
-nix build .#backend-image
+nix run .#backend-image-build
 ./result | sudo k3s ctr -n k8s.io images import -
 ```
 

--- a/flake.nix
+++ b/flake.nix
@@ -47,10 +47,9 @@
             program = "${self.packages.${system}.backend}/bin/server";
           };
         }
+        // import ./nix/backend-deps-apps.nix { inherit pkgs; }
         // import ./nix/k3s-apps.nix {
           inherit pkgs;
-          backendImage = packagesFor.${system}.backend-image;
-          frontendImage = packagesFor.${system}.frontend-image;
         }
       );
 

--- a/nix/backend-deps-apps.nix
+++ b/nix/backend-deps-apps.nix
@@ -1,0 +1,37 @@
+{ pkgs }:
+let
+  inherit (pkgs) lib;
+  dependencyTool = ../scripts/backend-deps.sh;
+  toApp = drv: {
+    type = "app";
+    program = lib.getExe drv;
+    meta.description = drv.meta.description or "";
+  };
+  mkDependencyApp =
+    operation: description:
+    toApp (
+      pkgs.writeShellApplication {
+        name = "backend-deps-${operation}";
+        meta.description = description;
+        runtimeInputs = [ pkgs.nix ];
+        text = ''
+          exec ${dependencyTool} ${operation} --repo-root "$PWD"
+        '';
+      }
+    );
+in
+{
+  backend-deps-refresh = mkDependencyApp "refresh" "Refresh the backend Nix dependency hash";
+  backend-deps-check = mkDependencyApp "check" "Check backend Nix dependency metadata without modifying it";
+  backend-image-build = toApp (
+    pkgs.writeShellApplication {
+      name = "backend-image-build";
+      meta.description = "Refresh backend dependency metadata and build the backend container image";
+      runtimeInputs = [ pkgs.nix ];
+      text = ''
+        ${dependencyTool} refresh --repo-root "$PWD"
+        exec nix build .#backend-image "$@"
+      '';
+    }
+  );
+}

--- a/nix/backend-vendor-hash.nix
+++ b/nix/backend-vendor-hash.nix
@@ -1,0 +1,1 @@
+"sha256-vyYkvxfSQPZerY7PDjaxF6IaIypMGTnmWT/kSzFl9w4="

--- a/nix/backend.nix
+++ b/nix/backend.nix
@@ -1,12 +1,14 @@
 # backend バイナリ。flake.nix から system ごとに import される。
-# go.mod / go.sum を変更したら vendorHash を更新すること
-# (lib.fakeHash に置き換えて nix build し、エラーに出る正しい hash を貼り直す)。
-{ pkgs }:
+# vendorHash は nix run .#backend-deps-refresh で更新する。
+{
+  pkgs,
+  vendorHash ? import ./backend-vendor-hash.nix,
+}:
 pkgs.buildGoModule {
   pname = "dsa-backend";
   version = "0.1.0";
   src = ../backend;
-  vendorHash = "sha256-vyYkvxfSQPZerY7PDjaxF6IaIypMGTnmWT/kSzFl9w4=";
+  inherit vendorHash;
   env.CGO_ENABLED = 0;
   # nix sandbox では Docker が使えないため、testcontainers を使う DB テストは
   # skip する (-short)。DB テストは GitHub Actions の codegen-and-db-test job で回す。

--- a/nix/k3s-apps.nix
+++ b/nix/k3s-apps.nix
@@ -8,15 +8,12 @@
 #
 # どれも状態は state dir (既定: $PWD/.k3s、DSA_K3S_STATE_DIR で変更可) に置き、
 # k3s-up 完了後は state dir 直下の kubeconfig で kubectl が使える。
-{
-  pkgs,
-  backendImage,
-  frontendImage,
-}:
+{ pkgs }:
 let
   inherit (pkgs) lib;
 
   chart = ../chart;
+  dependencyTool = ../scripts/backend-deps.sh;
 
   toApp = drv: {
     type = "app";
@@ -65,6 +62,7 @@ let
         kubernetes-helm
         kubectl
         coreutils
+        nix
       ];
       text = ''
         ${stateDirSnippet}
@@ -76,11 +74,14 @@ let
 
         ${lib.getExe loadImages}
 
+        backend_tag=$(nix eval --raw .#backend-image.imageTag)
+        frontend_tag=$(nix eval --raw .#frontend-image.imageTag)
+
         echo "Installing the Helm chart ..."
         helm upgrade --install dsa ${chart} \
           --kubeconfig "$kubeconfig" \
-          --set backend.image.tag=${backendImage.imageTag} \
-          --set frontend.image.tag=${frontendImage.imageTag} \
+          --set backend.image.tag="$backend_tag" \
+          --set frontend.image.tag="$frontend_tag" \
           --wait --timeout 5m
 
         node_ip=$(kubectl --kubeconfig "$kubeconfig" get nodes \
@@ -115,13 +116,18 @@ let
       loadImages = pkgs.writeShellApplication {
         name = "k3s-load-images";
         meta.description = "Import the container images into the host k3s server's containerd";
+        runtimeInputs = [ pkgs.nix ];
         text = ''
+          ${dependencyTool} refresh --repo-root "$PWD"
+          backend_image=$(nix build --no-link --print-out-paths .#backend-image)
+          frontend_image=$(nix build --no-link --print-out-paths .#frontend-image)
+
           # stream script を containerd (k8s.io namespace) へ直接 pipe する。
           # containerd の socket は root 所有のため sudo が要る。
-          echo "Importing dsa-backend:${backendImage.imageTag} (requires sudo) ..."
-          ${backendImage} | sudo ${pkgs.k3s}/bin/k3s ctr -n k8s.io images import -
-          echo "Importing dsa-frontend:${frontendImage.imageTag} ..."
-          ${frontendImage} | sudo ${pkgs.k3s}/bin/k3s ctr -n k8s.io images import -
+          echo "Importing the backend image (requires sudo) ..."
+          "$backend_image" | sudo ${pkgs.k3s}/bin/k3s ctr -n k8s.io images import -
+          echo "Importing the frontend image ..."
+          "$frontend_image" | sudo ${pkgs.k3s}/bin/k3s ctr -n k8s.io images import -
         '';
       };
     in

--- a/scripts/backend-deps-test.sh
+++ b/scripts/backend-deps-test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+dependency_tool="$repo_root/scripts/backend-deps.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+make_fixture() {
+  local fixture="$1"
+  mkdir -p "$fixture/nix" "$fixture/backend" "$fixture/bin"
+  cat >"$fixture/nix/backend-vendor-hash.nix" <<'EOF'
+"sha256-old"
+EOF
+  cat >"$fixture/nix/backend.nix" <<'EOF'
+{ pkgs }:
+pkgs.buildGoModule {
+  vendorHash = import ./backend-vendor-hash.nix;
+}
+EOF
+  touch "$fixture/backend/go.mod" "$fixture/backend/go.sum"
+  cat >"$fixture/bin/nix" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *"nix/backend.nix"* && "$*" == *"lib.fakeHash"* ]]; then
+  cat >&2 <<'OUTPUT'
+error: hash mismatch in fixed-output derivation
+         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+            got:    sha256-newnewnewnewnewnewnewnewnewnewnewnewnew=
+OUTPUT
+  exit 1
+fi
+echo "unexpected nix invocation: $*" >&2
+exit 64
+EOF
+  chmod +x "$fixture/bin/nix"
+}
+
+test_refresh_updates_metadata() {
+  local fixture
+  fixture="$(mktemp -d)"
+  trap 'rm -rf "$fixture"' RETURN
+  make_fixture "$fixture"
+
+  PATH="$fixture/bin:$PATH" "$dependency_tool" refresh --repo-root "$fixture"
+
+  grep -q '^"sha256-newnewnewnewnewnewnewnewnewnewnewnewnew="$' \
+    "$fixture/nix/backend-vendor-hash.nix" || fail "refresh did not write the calculated hash"
+}
+
+test_check_reports_drift_without_modifying_checkout() {
+  local fixture before output status
+  fixture="$(mktemp -d)"
+  trap 'rm -rf "$fixture"' RETURN
+  make_fixture "$fixture"
+  before="$(sha256sum "$fixture/nix/backend-vendor-hash.nix")"
+
+  set +e
+  output="$(PATH="$fixture/bin:$PATH" "$dependency_tool" check --repo-root "$fixture" 2>&1)"
+  status=$?
+  set -e
+
+  [[ $status -ne 0 ]] || fail "check accepted stale metadata"
+  [[ "$(sha256sum "$fixture/nix/backend-vendor-hash.nix")" == "$before" ]] || \
+    fail "check modified the checkout"
+  [[ "$output" == *"nix run .#backend-deps-refresh"* ]] || \
+    fail "check did not report the repair command"
+}
+
+test_flake_exposes_dependency_operations() {
+  nix eval --raw "$repo_root#apps.$(nix eval --raw --impure --expr builtins.currentSystem).backend-deps-refresh.program" \
+    >/dev/null
+  nix eval --raw "$repo_root#apps.$(nix eval --raw --impure --expr builtins.currentSystem).backend-deps-check.program" \
+    >/dev/null
+  nix eval --raw "$repo_root#apps.$(nix eval --raw --impure --expr builtins.currentSystem).backend-image-build.program" \
+    >/dev/null
+}
+
+test_refresh_updates_metadata
+test_check_reports_drift_without_modifying_checkout
+test_flake_exposes_dependency_operations
+echo "OK: backend dependency metadata operations"

--- a/scripts/backend-deps.sh
+++ b/scripts/backend-deps.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Keep buildGoModule's vendorHash synchronized with backend/go.mod and go.sum.
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 {refresh|check} [--repo-root PATH]" >&2
+  exit 2
+}
+
+operation="${1:-}"
+[[ "$operation" == "refresh" || "$operation" == "check" ]] || usage
+shift
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ "${1:-}" == "--repo-root" ]]; then
+  [[ $# -eq 2 ]] || usage
+  repo_root="$(cd "$2" && pwd)"
+elif [[ $# -ne 0 ]]; then
+  usage
+fi
+
+metadata="$repo_root/nix/backend-vendor-hash.nix"
+[[ -f "$metadata" ]] || {
+  echo "error: backend dependency metadata not found: $metadata" >&2
+  exit 1
+}
+
+current_hash="$(sed -n 's/^"\([^"]*\)"$/\1/p' "$metadata")"
+[[ -n "$current_hash" ]] || {
+  echo "error: vendorHash was not found in $metadata" >&2
+  exit 1
+}
+
+calculate_hash() {
+  local build_log status calculated
+  build_log="$(mktemp)"
+  set +e
+  (
+    cd "$repo_root"
+    nix build --no-link --impure --expr '
+      let
+        flake = builtins.getFlake (toString ./.);
+        pkgs = flake.inputs.nixpkgs.legacyPackages.${builtins.currentSystem};
+      in
+      import ./nix/backend.nix {
+        inherit pkgs;
+        vendorHash = pkgs.lib.fakeHash;
+      }
+    '
+  ) >"$build_log" 2>&1
+  status=$?
+  set -e
+
+  calculated="$(sed -n 's/^[[:space:]]*got:[[:space:]]*\(sha256-[^[:space:]]*\).*/\1/p' "$build_log" | tail -1)"
+  if [[ -z "$calculated" ]]; then
+    cat "$build_log" >&2
+    rm -f "$build_log"
+    if [[ $status -eq 0 ]]; then
+      echo "error: hash probe unexpectedly succeeded without reporting a hash" >&2
+    else
+      echo "error: could not calculate backend vendorHash" >&2
+    fi
+    exit 1
+  fi
+  rm -f "$build_log"
+  printf '%s\n' "$calculated"
+}
+
+expected_hash="$(calculate_hash)"
+
+if [[ "$current_hash" == "$expected_hash" ]]; then
+  echo "OK: backend dependency metadata is up to date"
+  exit 0
+fi
+
+if [[ "$operation" == "check" ]]; then
+  echo "error: backend dependency metadata is stale." >&2
+  echo "       committed: $current_hash" >&2
+  echo "       expected:  $expected_hash" >&2
+  echo "       Run 'nix run .#backend-deps-refresh' and commit nix/backend-vendor-hash.nix." >&2
+  exit 1
+fi
+
+sed -i "s|^\"$current_hash\"$|\"$expected_hash\"|" "$metadata"
+echo "Updated nix/backend-vendor-hash.nix:"
+echo "  $current_hash"
+echo "  -> $expected_hash"
+echo "The change is left in the working tree for review."


### PR DESCRIPTION
## Summary

- backend の Nix `vendorHash` を専用 metadata ファイルへ分離し、refresh/check 操作を追加
- backend image build と k3s image load/deploy の前に dependency drift を自動 refresh
- CI では checkout を変更せず drift を検査し、修復コマンドを含むエラーを表示
- dependency workflow の回帰テストと開発手順を追加

## Verification

- `bash scripts/backend-deps-test.sh`
- `nix run .#backend-deps-check`
- `nix run .#backend-image-build -- --no-link -L`
- `nix flake check -L`

Closes #116