### PR TITLE
Add k3s-first start and redeploy loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,34 @@ direnv をセットアップ済みなら、リポジトリのルートで一度�
 direnv allow
 ```
 
+## 開発ループ
+
+アプリケーションはホスト上で直接起動せず、PostgreSQL、Redis、backend、frontendを
+含む完全な構成をローカルk3sへデプロイして確認する。最初は次を実行する:
+
+```sh
+task start
+```
+
+`start` はk3sクラスタの準備、backend依存metadataのrefresh、content-derived tagを
+持つapplication imageのbuildとimport、local Kustomize overlayのapply、rollout、
+全application Podのreadiness確認まで行う。完了時に表示されるIngressのURLを
+ブラウザで開く。
+
+コードを編集した後は、明示的に再デプロイする:
+
+```sh
+task redeploy
+```
+
+`redeploy` はimageを再構築してk3sへ搬入し、現在のcontent-derived tagをmanifestへ
+注入する。内容が変わればDeploymentのPod templateも変わるため、rolloutが発生する。
+進行状況は `dependencies`、`build`、`import`、`secrets`、`apply`、`rollout`、
+`readiness` の段階ごとに表示される。ホットリロードやファイル監視は行わない。
+
+通常の `start` と `redeploy` はdevelopment PostgreSQLのPVCを削除しないため、
+セッションをまたいでデータを保持する。
+
 ## API contract と codegen
 
 クライアント向け REST API は `docs/spec/openapi.yaml` が single source of truth([ADR 0010](docs/adr/0010-openapi-contract-with-codegen.md))。変更したら両側のコードを再生成してコミットする:
@@ -63,10 +91,9 @@ task codegen:generate
 
 反映漏れは `task codegen:check` で検査できる(CI でも実行される)。
 
-## backend の実行とビルド
+## backend のビルド
 
 ```sh
-task backend:run            # サーバー起動 (PORT 環境変数で変更可、既定 8080)
 nix build .#backend         # バイナリ
 task backend:image:build    # 依存 metadata を refresh してコンテナイメージをビルド
 ```
@@ -87,7 +114,7 @@ task backend:deps:refresh # drift があれば作業ツリーを更新
 task backend:deps:check   # checkout を変更せず drift を検査 (CI と同じ)
 ```
 
-## frontend の開発とビルド
+## frontend の検査とビルド
 
 ```sh
 nix build .#frontend          # 静的ビルド成果物 (Vite の dist)
@@ -98,13 +125,10 @@ devShell 内では通常の npm ワークフローも使える:
 
 ```sh
 task frontend:install   # 初回と依存変更時
-task frontend:dev       # dev server (http://localhost:5173)
 task frontend:test      # vitest
 task frontend:typecheck # tsc -b
 task frontend:lint      # oxlint
 ```
-
-dev server は `/health` と `/api` を backend(`http://localhost:8080`)へ proxy する(`frontend/vite.config.ts`)。別ターミナルで `task backend:run` を起動しておくと、hello ページに backend の health check 結果が表示される。
 
 依存を変更したら `package.json` と `package-lock.json` をコミットする。Nix の frontend build は lockfile から依存を取得するため、Nix 固有の dependency hash の更新は不要。
 
@@ -125,7 +149,9 @@ frontend イメージは [static-web-server](https://static-web-server.net/) が
 
 デプロイの既定はシングルノード k3s クラスタ ([ADR 0008](docs/adr/0008-topology-agnostic-manifests.md))。Linux ホスト上で k3s server が systemd の一時 unit `dsa-k3s` として動く。`k3s-up` は `sudo systemd-run` を使うため、systemd と sudo が必要になる。OrbStack を使う場合も Linux machine 内で以下のコマンドを実行する。
 
-### 起動と停止
+### 低レベルのクラスタ操作
+
+通常は前述の `task start` を使う。クラスタだけを操作または診断する場合は次を使う:
 
 ```sh
 task k3s:up           # 起動し、ノードが Ready になるまで待つ
@@ -148,12 +174,12 @@ task k3s:down         # 停止
 - `k3s-up` は非 NixOS ホストでも動くが、systemd を前提とする
 - `k3s-down` で server を止めてもワークロードのコンテナは残り、次回起動時に再管理される
 
-## デプロイ (Kustomize)
+## 低レベルのデプロイ操作 (Kustomize)
 
-k3s 環境が起動済みなら 1 コマンド:
+通常の開発ループでは `task start` と `task redeploy` を使う。k3s環境が起動済みで、
+デプロイ部分だけを診断する場合は次を実行できる:
 
 ```sh
-task k3s:up            # 未起動の場合
 task k3s:deploy        # イメージ搬入 + local overlay の apply
 ```
 
@@ -163,8 +189,9 @@ task k3s:deploy        # イメージ搬入 + local overlay の apply
    - イメージの stream script をホストの containerd へ直接 pipe する (`sudo` が必要)
 2. **Secret基盤の収束** — version固定したSecrets Store CSI DriverとOpenBaoをHelmでinstall/upgradeし、disposableなdev serverへKubernetes auth、最小権限policy/role、既知の開発用passwordを冪等に設定する
 3. **local manifest のrenderとapply** — image tagはderivation hash由来で毎ビルド変わるため、一時コピー上のlocal overlayへ現在のtagを自動注入する。Git管理されたmanifestは変更しない
-4. **rollout待機** — backend / frontend のDeploymentが完了するまで待つ
-5. 完了後にアクセス URL (`http://<node-ip>/`) を表示する
+4. **rollout待機** — PostgreSQL / Redis / backend / frontend のrollout完了を待つ
+5. **readiness確認** — application PodがすべてReadyになるまで待つ
+6. 完了後にアクセス URL (`http://<node-ip>/`) を表示する
 
 ブラウザで URL を開くと hello ページが表示され、backend の health check 結果 (`ok`) が出る。Ingress は `/health` と `/api` を backend へ、それ以外を frontend へ route する。
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,11 +8,6 @@ tasks:
     cmds:
       - task --list
 
-  backend:run:
-    desc: Run the backend server
-    cmds:
-      - nix run .#backend
-
   backend:test:
     desc: Run backend unit tests
     dir: backend
@@ -41,12 +36,6 @@ tasks:
     dir: frontend
     cmds:
       - npm ci
-
-  frontend:dev:
-    desc: Run the frontend development server
-    dir: frontend
-    cmds:
-      - npm run dev
 
   frontend:test:
     desc: Run frontend unit tests
@@ -100,6 +89,16 @@ tasks:
     desc: Create an initial production datastore secret
     cmds:
       - nu scripts/openbao-set-production-secret.nu {{.CLI_ARGS}}
+
+  start:
+    desc: Start the complete application on local k3s
+    cmds:
+      - nu scripts/k3s.nu start
+
+  redeploy:
+    desc: Rebuild and redeploy the application on local k3s
+    cmds:
+      - nu scripts/k3s.nu redeploy
 
   k3s:up:
     desc: Start the local single-node k3s server

--- a/scripts/k3s.nu
+++ b/scripts/k3s.nu
@@ -20,13 +20,17 @@ def run-checked [description: string, args: list<string>] {
   $result.stdout
 }
 
+def stage [name: string, message: string] {
+  print $"[($name)] ($message)"
+}
+
 def unit-active [] {
   (do { ^systemctl is-active --quiet $unit } | complete).exit_code == 0
 }
 
 def wait-for-node [state_dir: path] {
   let kubeconfig = $state_dir | path join kubeconfig
-  print 'Waiting for the node to become Ready ...'
+  stage cluster 'Waiting for the node to become Ready ...'
   mut ready = false
   for _ in 1..180 {
     let nodes = do { ^kubectl --kubeconfig $kubeconfig get nodes --no-headers } | complete
@@ -52,23 +56,26 @@ def load-images [root: path] {
   # sudo commonly replaces PATH with secure_path, which excludes Nix store paths.
   let k3s = which k3s | get 0.path
 
+  stage dependencies 'Refreshing backend dependency metadata ...'
   run-checked 'failed to refresh backend dependency metadata' [
     nu ($root | path join scripts backend-deps.nu) refresh
   ] | ignore
 
+  stage build 'Building the backend image ...'
   let backend_image = run-checked 'failed to build the backend image' [
     nix build --no-link --print-out-paths $"($root)#backend-image"
   ] | str trim
+  stage build 'Building the frontend image ...'
   let frontend_image = run-checked 'failed to build the frontend image' [
     nix build --no-link --print-out-paths $"($root)#frontend-image"
   ] | str trim
 
-  print 'Importing the backend image (requires sudo) ...'
+  stage import 'Importing the backend image (requires sudo) ...'
   run-external $backend_image | ^sudo $k3s ctr -n k8s.io images import -
   if $env.LAST_EXIT_CODE != 0 {
     error make { msg: 'failed to import the backend image' }
   }
-  print 'Importing the frontend image ...'
+  stage import 'Importing the frontend image ...'
   run-external $frontend_image | ^sudo $k3s ctr -n k8s.io images import -
   if $env.LAST_EXIT_CODE != 0 {
     error make { msg: 'failed to import the frontend image' }
@@ -98,10 +105,10 @@ def render-local-manifests [root: path, backend_tag: string, frontend_tag: strin
 }
 
 def main [] {
-  error make { msg: 'usage: task k3s:{up|down|load-images|deploy}' }
+  error make { msg: 'usage: task {start|redeploy} or task k3s:{up|down|load-images|deploy}' }
 }
 
-def 'main up' [] {
+def ensure-cluster [] {
   let root = repo-root
   let state_dir = state-dir $root
   mkdir $state_dir
@@ -109,9 +116,9 @@ def 'main up' [] {
   let group = ^id -gn | str trim
 
   if (unit-active) {
-    print $"k3s server is already running; systemd unit: ($unit)"
+    stage cluster $"k3s server is already running; systemd unit: ($unit)"
   } else {
-    print $"Starting the k3s server as transient systemd unit ($unit); requires sudo ..."
+    stage cluster $"Starting the k3s server as transient systemd unit ($unit); requires sudo ..."
     let executable_path = $env.PATH | str join ':'
     run-checked 'failed to start the k3s systemd unit' [
       sudo systemd-run $"--unit=($unit)"
@@ -124,7 +131,7 @@ def 'main up' [] {
     ] | ignore
   }
 
-  print 'Waiting for the kubeconfig ...'
+  stage cluster 'Waiting for the kubeconfig ...'
   mut found = false
   for _ in 1..300 {
     let exists = (do { ^test -s $kubeconfig } | complete).exit_code == 0
@@ -144,6 +151,10 @@ def 'main up' [] {
   wait-for-node $state_dir
 }
 
+def 'main up' [] {
+  ensure-cluster
+}
+
 def 'main down' [] {
   if (unit-active) {
     print $"Stopping systemd unit ($unit); requires sudo ..."
@@ -158,17 +169,17 @@ def 'main load-images' [] {
   load-images (repo-root)
 }
 
-def 'main deploy' [] {
+def converge-development-environment [] {
   let root = repo-root
   let state_dir = state-dir $root
   let kubeconfig = $state_dir | path join kubeconfig
   if not ($kubeconfig | path exists) or (($kubeconfig | path type) != file) {
-    error make { msg: $"kubeconfig not found at ($kubeconfig); run 'task k3s:up' first" }
+    error make { msg: $"kubeconfig not found at ($kubeconfig); run 'task start' first" }
   }
 
   load-images $root
   with-env { KUBECONFIG: $kubeconfig } {
-    print 'Installing and configuring local OpenBao ...'
+    stage secrets 'Installing and configuring local OpenBao ...'
     run-checked 'failed to install local OpenBao' [
       nu ($root | path join scripts openbao-install.nu) dev
     ] | ignore
@@ -184,18 +195,48 @@ def 'main deploy' [] {
     ] | str trim
     let manifests = render-local-manifests $root $backend_tag $frontend_tag
 
-    print 'Applying the local Kubernetes manifests ...'
+    stage apply 'Applying the local Kubernetes manifests ...'
     let apply = $manifests | ^kubectl apply -f - | complete
     if $apply.exit_code != 0 {
       print --stderr $apply.stdout
       print --stderr $apply.stderr
       error make { msg: 'failed to apply local Kubernetes manifests' }
     }
-    ^kubectl rollout status deployment/dsa-backend --timeout=5m
-    ^kubectl rollout status deployment/dsa-frontend --timeout=5m
+    for workload in [
+      'statefulset/dsa-postgresql'
+      'deployment/dsa-redis'
+      'deployment/dsa-backend'
+      'deployment/dsa-frontend'
+    ] {
+      stage rollout $"Waiting for ($workload) ..."
+      run-checked $"rollout failed for ($workload)" [
+        kubectl rollout status $workload --timeout=5m
+      ] | print
+    }
+
+    stage readiness 'Waiting for all application Pods to become Ready ...'
+    run-checked 'application Pods did not become Ready' [
+      kubectl wait pod
+      --selector=app.kubernetes.io/name=dsa
+      --for=condition=Ready
+      --timeout=5m
+    ] | print
 
     let node_ip = ^kubectl get nodes -o 'jsonpath={.items[0].status.addresses[?(@.type=="InternalIP")].address}'
     print ''
-    print $"Deployed. Open: http://($node_ip)/"
+    stage ready $"Open: http://($node_ip)/"
   }
+}
+
+def 'main deploy' [] {
+  converge-development-environment
+}
+
+def 'main start' [] {
+  ensure-cluster
+  converge-development-environment
+}
+
+def 'main redeploy' [] {
+  converge-development-environment
 }


### PR DESCRIPTION
## Summary

- add top-level `task start` and `task redeploy` commands for the k3s-first edit-to-verification loop
- show distinct dependency, build, import, apply, rollout, and readiness stages
- wait for PostgreSQL, Redis, backend, and frontend while preserving the development PostgreSQL PVC
- document the deployed Ingress workflow and remove host-process application commands

## Testing

- `nu --no-config-file --commands "nu-check scripts/k3s.nu"`
- `task frontend:typecheck`
- `task backend:test`
- `task codegen:check`
- `task check`

Closes #118