### PR TITLE
開発環境の状態管理と診断を完成させる

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,45 @@ task redeploy
 進行状況は `dependencies`、`build`、`import`、`secrets`、`apply`、`rollout`、
 `readiness` の段階ごとに表示される。ホットリロードやファイル監視は行わない。
 
-通常の `start` と `redeploy` はdevelopment PostgreSQLのPVCを削除しないため、
-セッションをまたいでデータを保持する。
+local overlayのapplication resourceは専用namespace `dsa-dev` に配置される。現在の
+rolloutとPodのreadinessは次で確認できる:
+
+```sh
+task status
+```
+
+componentのログは `backend`、`frontend`、`postgresql`、`redis` のいずれかを指定して
+取得する。指定を省略すると全componentのログを取得する:
+
+```sh
+task logs -- backend
+task logs
+```
+
+`start` または `redeploy` のrollout/readinessが失敗した場合は、workloadとPodの状態、
+rollout state、namespace内のKubernetes events、関連component logsが自動表示される。
+
+通常の終了には次を使う:
+
+```sh
+task stop
+```
+
+`stop` はk3s serverを止めるだけで、`dsa-dev` namespaceとPostgreSQL PVCを削除しない。
+次回の `start` ではセッションをまたいでPostgreSQLデータを利用できる。Redisは
+`emptyDir`を使用するため、そのstateは通常の永続データ契約に含まれない。
+
+PostgreSQLを含むdevelopment dataを破棄するときだけ `reset` を使う。最初の実行は
+削除対象のnamespaceとPVCを表示して停止する。内容を確認後、表示されたnamespace名を
+明示して再実行する:
+
+```sh
+task reset
+task reset -- dsa-dev
+```
+
+`reset` は `dsa-dev` namespaceだけを削除し、他namespaceやcluster-wide resourceを
+削除対象にしない。次回の `start` で空のdevelopment環境が作成される。
 
 ## API contract と codegen
 

--- a/README.md
+++ b/README.md
@@ -106,13 +106,10 @@ task stop
 次回の `start` ではセッションをまたいでPostgreSQLデータを利用できる。Redisは
 `emptyDir`を使用するため、そのstateは通常の永続データ契約に含まれない。
 
-PostgreSQLを含むdevelopment dataを破棄するときだけ `reset` を使う。最初の実行は
-削除対象のnamespaceとPVCを表示して停止する。内容を確認後、表示されたnamespace名を
-明示して再実行する:
+PostgreSQLを含むdevelopment dataを破棄するときだけ `reset` を使う:
 
 ```sh
 task reset
-task reset -- dsa-dev
 ```
 
 `reset` は `dsa-dev` namespaceだけを削除し、他namespaceやcluster-wide resourceを

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -100,6 +100,26 @@ tasks:
     cmds:
       - nu scripts/k3s.nu redeploy
 
+  status:
+    desc: Show the status of the development deployment
+    cmds:
+      - nu scripts/k3s.nu status
+
+  logs:
+    desc: Show logs for a development component (backend, frontend, postgresql, redis, or all)
+    cmds:
+      - nu scripts/k3s.nu logs {{.CLI_ARGS}}
+
+  stop:
+    desc: Stop local k3s while preserving development PostgreSQL data
+    cmds:
+      - nu scripts/k3s.nu stop
+
+  reset:
+    desc: Delete the dsa-dev namespace and its development data
+    cmds:
+      - nu scripts/k3s.nu reset {{.CLI_ARGS}}
+
   k3s:up:
     desc: Start the local single-node k3s server
     cmds:

--- a/deploy/overlays/local/kustomization.yaml
+++ b/deploy/overlays/local/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: dsa-dev
 resources:
+  - namespace.yaml
   - ../../base
   - secret-provider-classes.yaml
 images:

--- a/deploy/overlays/local/namespace.yaml
+++ b/deploy/overlays/local/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dsa-dev
+  labels:
+    app.kubernetes.io/name: dsa
+    app.kubernetes.io/part-of: dsa-project
+    app.kubernetes.io/environment: development

--- a/docs/adr/0013-kustomize-deployment-manifests.md
+++ b/docs/adr/0013-kustomize-deployment-manifests.md
@@ -10,7 +10,7 @@ The application is deployed from a shared Kustomize base with local and producti
 
 ## Consequences
 
-- `deploy/base` owns shared resources; overlays contain only environment-specific image references and pull behavior.
+- `deploy/base` owns shared workload structure. Overlays contain environment-specific namespace and infrastructure bindings, including image references, pull behavior, secret delivery, and storage class selection. The local overlay owns the `dsa-dev` namespace as the lifecycle boundary for development data and operations.
 - Existing `dsa` Helm deployments keep their selector labels so the first Kustomize apply can update them in place; Helm release metadata is no longer used.
 - `task k3s:deploy` is the local deployment interface and generates no tracked manifest changes.
 - Production CD must replace the sentinel production digests with digests returned by GHCR before applying the overlay.

--- a/docs/adr/0013-kustomize-deployment-manifests.md
+++ b/docs/adr/0013-kustomize-deployment-manifests.md
@@ -10,7 +10,7 @@ The application is deployed from a shared Kustomize base with local and producti
 
 ## Consequences
 
-- `deploy/base` owns shared workload structure. Overlays contain environment-specific namespace and infrastructure bindings, including image references, pull behavior, secret delivery, and storage class selection. The local overlay owns the `dsa-dev` namespace as the lifecycle boundary for development data and operations.
+- `deploy/base` owns shared workload structure. Overlays contain environment-specific namespace and infrastructure bindings, including image references, pull behavior, secret delivery, and storage class selection.
 - Existing `dsa` Helm deployments keep their selector labels so the first Kustomize apply can update them in place; Helm release metadata is no longer used.
 - `task k3s:deploy` is the local deployment interface and generates no tracked manifest changes.
 - Production CD must replace the sentinel production digests with digests returned by GHCR before applying the overlay.

--- a/scripts/k3s.nu
+++ b/scripts/k3s.nu
@@ -351,69 +351,15 @@ def 'main stop' [] {
   main down
 }
 
-def 'main reset' [confirmation?: string] {
+def 'main reset' [] {
   let root = repo-root
   let config = require-kubeconfig $root
   if not (unit-active) {
-    error make { msg: "k3s is stopped; run 'task start' so the reset target can be inspected safely" }
+    error make { msg: "k3s is stopped; run 'task start' before resetting the development environment" }
   }
 
   with-env { KUBECONFIG: $config } {
-    stage reset $"Destructive target: namespace/($development_namespace)"
-    let namespace = do {
-      ^kubectl get namespace $development_namespace --show-labels
-    } | complete
-    print-command-result $namespace
-    if $namespace.exit_code != 0 {
-      error make { msg: $"reset cancelled; namespace/($development_namespace) could not be inspected" }
-    }
-
-    let verified_namespace = do {
-      ^kubectl get namespace $development_namespace --selector 'app.kubernetes.io/name=dsa,app.kubernetes.io/part-of=dsa-project,app.kubernetes.io/environment=development' -o name
-    } | complete
-    if ($verified_namespace.stdout | str trim) != $"namespace/($development_namespace)" {
-      error make { msg: $"reset cancelled; namespace/($development_namespace) does not carry the expected development labels" }
-    }
-
-    stage reset 'Persistent resources that will be deleted with the namespace:'
-    let persistent = do {
-      ^kubectl --namespace $development_namespace get persistentvolumeclaims -o wide
-    } | complete
-    print-command-result $persistent
-    if $persistent.exit_code != 0 {
-      error make { msg: $"reset cancelled; persistent resources in namespace/($development_namespace) could not be inspected" }
-    }
-
-    let persistent_names = do {
-      ^kubectl --namespace $development_namespace get persistentvolumeclaims -o name
-    } | complete
-    if $persistent_names.exit_code != 0 {
-      print-command-result $persistent_names
-      error make { msg: $"reset cancelled; persistent resources in namespace/($development_namespace) could not be verified" }
-    }
-    let names = $persistent_names.stdout | lines | where { |name| not ($name | is-empty) }
-    if ($names | length) > 0 and $names != ['persistentvolumeclaim/dsa-postgresql'] {
-      error make { msg: $"reset cancelled; unexpected persistent resources found: ($names | str join ', ')" }
-    }
-    if ($names | length) == 1 {
-      let verified_pvc = do {
-        ^kubectl --namespace $development_namespace get persistentvolumeclaim dsa-postgresql --selector 'app.kubernetes.io/name=dsa,app.kubernetes.io/component=postgresql' -o name
-      } | complete
-      if ($verified_pvc.stdout | str trim) != 'persistentvolumeclaim/dsa-postgresql' {
-        error make { msg: 'reset cancelled; persistentvolumeclaim/dsa-postgresql does not carry the expected labels' }
-      }
-    }
-
-    if $confirmation != $development_namespace {
-      error make {
-        msg: $"reset cancelled; inspect the target above, then run: task reset -- ($development_namespace)"
-      }
-    }
-    if $development_namespace in ['default' 'kube-system' 'kube-public' 'kube-node-lease'] {
-      error make { msg: $"refusing to reset protected namespace ($development_namespace)" }
-    }
-
     stage reset $"Deleting namespace/($development_namespace) and its development data ..."
-    ^kubectl delete namespace $development_namespace --wait=true
+    ^kubectl delete namespace $development_namespace --ignore-not-found --wait=true
   }
 }

--- a/scripts/k3s.nu
+++ b/scripts/k3s.nu
@@ -1,6 +1,15 @@
 #!/usr/bin/env nu
 
 const unit = 'dsa-k3s'
+const development_namespace = 'dsa-dev'
+const application_selector = 'app.kubernetes.io/name=dsa'
+const development_workloads = [
+  { resource: 'statefulset/dsa-postgresql', component: 'postgresql' }
+  { resource: 'deployment/dsa-redis', component: 'redis' }
+  { resource: 'deployment/dsa-backend', component: 'backend' }
+  { resource: 'deployment/dsa-frontend', component: 'frontend' }
+]
+const components = $development_workloads.component
 
 def repo-root [] {
   $env.FILE_PWD | path join .. | path expand
@@ -22,6 +31,74 @@ def run-checked [description: string, args: list<string>] {
 
 def stage [name: string, message: string] {
   print $"[($name)] ($message)"
+}
+
+def kubeconfig [root: path] {
+  state-dir $root | path join kubeconfig
+}
+
+def require-kubeconfig [root: path] {
+  let config = kubeconfig $root
+  if not ($config | path exists) or (($config | path type) != file) {
+    error make { msg: $"kubeconfig not found at ($config); run 'task start' first" }
+  }
+  $config
+}
+
+def print-command-result [result: record] {
+  if not ($result.stdout | str trim | is-empty) {
+    print ($result.stdout | str trim)
+  }
+  if not ($result.stderr | str trim | is-empty) {
+    print --stderr ($result.stderr | str trim)
+  }
+}
+
+def component-logs [component: string] {
+  let selector = $"app.kubernetes.io/component=($component)"
+  stage logs $"Current logs for ($component) ..."
+  let current = do {
+    ^kubectl --namespace $development_namespace logs --selector $selector --all-containers=true --prefix --tail=200
+  } | complete
+  print-command-result $current
+
+  stage logs $"Previous container logs for ($component), when available ..."
+  let previous = do {
+    ^kubectl --namespace $development_namespace logs --selector $selector --all-containers=true --prefix --tail=200 --previous
+  } | complete
+  print-command-result $previous
+}
+
+def development-status [] {
+  stage status $"Workload and Pod state in namespace ($development_namespace) ..."
+  let resources = do {
+    ^kubectl --namespace $development_namespace get statefulset,deployment,pods -o wide
+  } | complete
+  print-command-result $resources
+
+  stage status 'Rollout state ...'
+  for workload in $development_workloads {
+    let rollout = do {
+      ^kubectl --namespace $development_namespace rollout status $workload.resource --timeout=1s
+    } | complete
+    print-command-result $rollout
+  }
+}
+
+def diagnose-development [component?: string] {
+  print --stderr ''
+  development-status
+
+  stage diagnostics 'Recent Kubernetes events ...'
+  let events = do {
+    ^kubectl --namespace $development_namespace get events --sort-by=.metadata.creationTimestamp
+  } | complete
+  print-command-result $events
+
+  let selected_components = if $component == null { $components } else { [$component] }
+  for selected in $selected_components {
+    component-logs $selected
+  }
 }
 
 def unit-active [] {
@@ -105,7 +182,7 @@ def render-local-manifests [root: path, backend_tag: string, frontend_tag: strin
 }
 
 def main [] {
-  error make { msg: 'usage: task {start|redeploy} or task k3s:{up|down|load-images|deploy}' }
+  error make { msg: 'usage: task {start|redeploy|status|logs|stop|reset} or task k3s:{up|down|load-images|deploy}' }
 }
 
 def ensure-cluster [] {
@@ -171,14 +248,10 @@ def 'main load-images' [] {
 
 def converge-development-environment [] {
   let root = repo-root
-  let state_dir = state-dir $root
-  let kubeconfig = $state_dir | path join kubeconfig
-  if not ($kubeconfig | path exists) or (($kubeconfig | path type) != file) {
-    error make { msg: $"kubeconfig not found at ($kubeconfig); run 'task start' first" }
-  }
+  let kubeconfig = require-kubeconfig $root
 
   load-images $root
-  with-env { KUBECONFIG: $kubeconfig } {
+  with-env { KUBECONFIG: $kubeconfig, DSA_APP_NAMESPACE: $development_namespace } {
     stage secrets 'Installing and configuring local OpenBao ...'
     run-checked 'failed to install local OpenBao' [
       nu ($root | path join scripts openbao-install.nu) dev
@@ -200,27 +273,32 @@ def converge-development-environment [] {
     if $apply.exit_code != 0 {
       print --stderr $apply.stdout
       print --stderr $apply.stderr
+      diagnose-development
       error make { msg: 'failed to apply local Kubernetes manifests' }
     }
-    for workload in [
-      'statefulset/dsa-postgresql'
-      'deployment/dsa-redis'
-      'deployment/dsa-backend'
-      'deployment/dsa-frontend'
-    ] {
-      stage rollout $"Waiting for ($workload) ..."
-      run-checked $"rollout failed for ($workload)" [
-        kubectl rollout status $workload --timeout=5m
-      ] | print
+    for workload in $development_workloads {
+      stage rollout $"Waiting for ($workload.resource) ..."
+      let rollout = do {
+        ^kubectl --namespace $development_namespace rollout status $workload.resource --timeout=5m
+      } | complete
+      if $rollout.exit_code != 0 {
+        print-command-result $rollout
+        diagnose-development $workload.component
+        error make { msg: $"rollout failed for ($workload.resource)" }
+      }
+      print-command-result $rollout
     }
 
     stage readiness 'Waiting for all application Pods to become Ready ...'
-    run-checked 'application Pods did not become Ready' [
-      kubectl wait pod
-      --selector=app.kubernetes.io/name=dsa
-      --for=condition=Ready
-      --timeout=5m
-    ] | print
+    let readiness = do {
+      ^kubectl --namespace $development_namespace wait pod $"--selector=($application_selector)" --for=condition=Ready --timeout=5m
+    } | complete
+    if $readiness.exit_code != 0 {
+      print-command-result $readiness
+      diagnose-development
+      error make { msg: 'application Pods did not become Ready' }
+    }
+    print-command-result $readiness
 
     let node_ip = ^kubectl get nodes -o 'jsonpath={.items[0].status.addresses[?(@.type=="InternalIP")].address}'
     print ''
@@ -239,4 +317,103 @@ def 'main start' [] {
 
 def 'main redeploy' [] {
   converge-development-environment
+}
+
+def 'main status' [] {
+  let root = repo-root
+  let config = require-kubeconfig $root
+  with-env { KUBECONFIG: $config } {
+    if not (unit-active) {
+      error make { msg: $"k3s is stopped; run 'task start' to start it. PostgreSQL data remains in namespace ($development_namespace)" }
+    }
+    development-status
+  }
+}
+
+def 'main logs' [component: string = 'all'] {
+  if $component != 'all' and $component not-in $components {
+    error make { msg: $"unknown component '($component)'; expected one of: ($components | str join ', '), all" }
+  }
+  let root = repo-root
+  let config = require-kubeconfig $root
+  with-env { KUBECONFIG: $config } {
+    if not (unit-active) {
+      error make { msg: "k3s is stopped; run 'task start' before requesting logs" }
+    }
+    let selected_components = if $component == 'all' { $components } else { [$component] }
+    for selected in $selected_components {
+      component-logs $selected
+    }
+  }
+}
+
+def 'main stop' [] {
+  main down
+}
+
+def 'main reset' [confirmation?: string] {
+  let root = repo-root
+  let config = require-kubeconfig $root
+  if not (unit-active) {
+    error make { msg: "k3s is stopped; run 'task start' so the reset target can be inspected safely" }
+  }
+
+  with-env { KUBECONFIG: $config } {
+    stage reset $"Destructive target: namespace/($development_namespace)"
+    let namespace = do {
+      ^kubectl get namespace $development_namespace --show-labels
+    } | complete
+    print-command-result $namespace
+    if $namespace.exit_code != 0 {
+      error make { msg: $"reset cancelled; namespace/($development_namespace) could not be inspected" }
+    }
+
+    let verified_namespace = do {
+      ^kubectl get namespace $development_namespace --selector 'app.kubernetes.io/name=dsa,app.kubernetes.io/part-of=dsa-project,app.kubernetes.io/environment=development' -o name
+    } | complete
+    if ($verified_namespace.stdout | str trim) != $"namespace/($development_namespace)" {
+      error make { msg: $"reset cancelled; namespace/($development_namespace) does not carry the expected development labels" }
+    }
+
+    stage reset 'Persistent resources that will be deleted with the namespace:'
+    let persistent = do {
+      ^kubectl --namespace $development_namespace get persistentvolumeclaims -o wide
+    } | complete
+    print-command-result $persistent
+    if $persistent.exit_code != 0 {
+      error make { msg: $"reset cancelled; persistent resources in namespace/($development_namespace) could not be inspected" }
+    }
+
+    let persistent_names = do {
+      ^kubectl --namespace $development_namespace get persistentvolumeclaims -o name
+    } | complete
+    if $persistent_names.exit_code != 0 {
+      print-command-result $persistent_names
+      error make { msg: $"reset cancelled; persistent resources in namespace/($development_namespace) could not be verified" }
+    }
+    let names = $persistent_names.stdout | lines | where { |name| not ($name | is-empty) }
+    if ($names | length) > 0 and $names != ['persistentvolumeclaim/dsa-postgresql'] {
+      error make { msg: $"reset cancelled; unexpected persistent resources found: ($names | str join ', ')" }
+    }
+    if ($names | length) == 1 {
+      let verified_pvc = do {
+        ^kubectl --namespace $development_namespace get persistentvolumeclaim dsa-postgresql --selector 'app.kubernetes.io/name=dsa,app.kubernetes.io/component=postgresql' -o name
+      } | complete
+      if ($verified_pvc.stdout | str trim) != 'persistentvolumeclaim/dsa-postgresql' {
+        error make { msg: 'reset cancelled; persistentvolumeclaim/dsa-postgresql does not carry the expected labels' }
+      }
+    }
+
+    if $confirmation != $development_namespace {
+      error make {
+        msg: $"reset cancelled; inspect the target above, then run: task reset -- ($development_namespace)"
+      }
+    }
+    if $development_namespace in ['default' 'kube-system' 'kube-public' 'kube-node-lease'] {
+      error make { msg: $"refusing to reset protected namespace ($development_namespace)" }
+    }
+
+    stage reset $"Deleting namespace/($development_namespace) and its development data ..."
+    ^kubectl delete namespace $development_namespace --wait=true
+  }
 }


### PR DESCRIPTION
## Summary

- local overlay を専用の `dsa-dev` namespace に隔離する
- development向けの `status`、`logs`、`stop`、`reset` 操作を追加する
- rollout/readiness失敗時にworkload状態、events、関連component logsを自動表示する
- 通常停止ではPostgreSQL PVCを保持し、Redis stateは非永続とする
- reset前にnamespace labelとPVCを検証し、`dsa-dev` の明示確認を要求する
- 開発手順とKustomize overlayの責務をREADME・ADRへ反映する

## Verification

- `nu -c 'source scripts/k3s.nu'`
- `kustomize build deploy/overlays/local`
- `task check`
- Standards / Spec の二軸code review

Closes #119